### PR TITLE
Fix Markdown math rendering in core files

### DIFF
--- a/Factorial.md
+++ b/Factorial.md
@@ -4,101 +4,101 @@ Source: algebrica.org — CC BY-NC 4.0
 
 ## Definition
 
-The factorial of a non-negative [integer](../types-of-numbers/) \\(n\\), written \\(n!\\), is the product of all positive integers from \\(1\\) to \\(n\\):
+The factorial of a non-negative [integer](../types-of-numbers/) $n$, written $n!$, is the product of all positive integers from $1$ to $n$:
 
-\\[
+$$
 \begin{align}
-n! &= n \cdot (n-1) \cdot (n-2) \cdot \ldots \cdot 2 \cdot 1 \\\\[6pt]
+n! &= n \cdot (n-1) \cdot (n-2) \cdot \ldots \cdot 2 \cdot 1 \\[6pt]
 &= n \cdot (n-1)!
 \end{align}
-\\]
+$$
 
-For example, the factorial of \\(4\\) is computed as follows:
+For example, the factorial of $4$ is computed as follows:
 
-\\[
+$$
 4! = 4 \cdot 3 \cdot 2 \cdot 1 = 24
-\\]
+$$
 
-By convention, the factorial of \\(0\\) is equal to \\(1\\).
+By convention, the factorial of $0$ is equal to $1$.
 
 The factorial can also be expressed through a recursive [function](../functions/) defined by cases:
 
-\\[
+$$
 n! =
 \begin{cases}
-n \cdot (n-1)! & \text{if } n \in \mathbb{N},\ n > 0 \\\\[6pt]
+n \cdot (n-1)! & \text{if } n \in \mathbb{N},\ n > 0 \\[6pt]
 1 & \text{if } n = 0
 \end{cases}
-\\]
+$$
 
-The same definition can be written more compactly using the product symbol \\(\prod\\), where the index \\(k\\) ranges from \\(1\\) to \\(n\\):
+The same definition can be written more compactly using the product symbol $\prod$, where the index $k$ ranges from $1$ to $n$:
 
-\\[
+$$
 n! =
 \begin{cases}
-\displaystyle\prod_{k=1}^{n} k & \text{if } n \in \mathbb{N},\ n > 0 \\\\[6pt]
+\displaystyle\prod_{k=1}^{n} k & \text{if } n \in \mathbb{N},\ n > 0 \\[6pt]
 1 & \text{if } n = 0
 \end{cases}
-\\]
+$$
 
 The factorial is used to compute the [binomial coefficient](../binomial-coefficient/), which represents the number of ways to select a given number of elements from a larger set.
 
 - - -
-- 
+
 ## Simplifying factorial ratios
 
-Suppose we are given two non-negative integers \\(n\\) and \\(k\\) with \\(n > k\\), and we want to compute the following ratio:
+Suppose we are given two non-negative integers $n$ and $k$ with $n > k$, and we want to compute the following ratio:
 
-\\[
+$$
 \frac{n!}{(n-k)!}
-\\]
+$$
 
-The denominator cancels the factors from \\((n-k)\\) to \\(1\\), leaving \\(k\\) terms in the numerator.
+The denominator cancels the factors from $(n-k)$ to $1$, leaving $k$ terms in the numerator.
 
-\\[
+$$
 \frac{n!}{(n-k)!} = n \cdot (n-1) \cdot \ldots \cdot (n-k+1)
-\\]
+$$
 
-Consider the ratio between \\(7!\\) and \\(4!\\). The factors from \\(4\\) down to \\(1\\) appear in both numerator and denominator and therefore cancel. What remains in the numerator is the product of the integers from \\(7\\) down to \\(5\\), which is equal to \\(210\\):
+Consider the ratio between $7!$ and $4!$. The factors from $4$ down to $1$ appear in both numerator and denominator and therefore cancel. What remains in the numerator is the product of the integers from $7$ down to $5$, which is equal to $210$:
 
-\\[
+$$
 \frac{7!}{4!} = \frac{7 \cdot 6 \cdot 5 \cdot 4 \cdot 3 \cdot 2 \cdot 1}{4 \cdot 3 \cdot 2 \cdot 1} = 7 \cdot 6 \cdot 5 = 210
-\\]
+$$
 
 - - -
 
 ## Factorial in combinatorics
 
-In combinatorics, \\(n!\\) counts the possible permutations of \\(n\\) objects. For example, with \\(n = 3\\) objects there are \\(3! = 6\\) possible permutations:
+In combinatorics, $n!$ counts the possible permutations of $n$ objects. For example, with $n = 3$ objects there are $3! = 6$ possible permutations:
 
-\\[
+$$
 \begin{array}{rrrr}
-& o_1 & o_2 & o_3 \\\\[6pt]
+& o_1 & o_2 & o_3 \\[6pt]
 \hline
-& 1 & 2 & 3 \\\\[6pt]
-& 1 & 3 & 2 \\\\[6pt]
-& 2 & 1 & 3 \\\\[6pt]
-& 2 & 3 & 1 \\\\[6pt]
-& 3 & 1 & 2 \\\\[6pt]
+& 1 & 2 & 3 \\[6pt]
+& 1 & 3 & 2 \\[6pt]
+& 2 & 1 & 3 \\[6pt]
+& 2 & 3 & 1 \\[6pt]
+& 3 & 1 & 2 \\[6pt]
 & 3 & 2 & 1
 \end{array}
-\\]
+$$
 
-If the order of selection does not matter, many of these orderings become equivalent. Choosing the objects \\(1, 2, 3\\) is the same as choosing \\(3, 2, 1\\) or any other arrangement of the same three elements. Since each group of \\(k\\) elements can be arranged in \\(k!\\) different ways, dividing by \\(k!\\) eliminates these repetitions and yields the [binomial coefficient](../binomial-coefficient/):
+If the order of selection does not matter, many of these orderings become equivalent. Choosing the objects $1, 2, 3$ is the same as choosing $3, 2, 1$ or any other arrangement of the same three elements. Since each group of $k$ elements can be arranged in $k!$ different ways, dividing by $k!$ eliminates these repetitions and yields the [binomial coefficient](../binomial-coefficient/):
 
-\\[
-\binom{n}{k} = \frac{n!}{k! \\, (n-k)!}
-\\]
+$$
+\binom{n}{k} = \frac{n!}{k! \, (n-k)!}
+$$
 
 - - -
 
 ## A useful identity involving factorial
 
-Starting from the recursive definition \\(n! = n \cdot (n-1)!\\) and substituting it into the denominator of the fraction \\(n/n!\\), the factor \\(n\\) cancels out and we obtain the following identity, which is often useful to simplify expressions involving factorials:
+Starting from the recursive definition $n! = n \cdot (n-1)!$ and substituting it into the denominator of the fraction $n/n!$, the factor $n$ cancels out and we obtain the following identity, which is often useful to simplify expressions involving factorials:
 
-\\[
+$$
 \frac{n}{n!} = \frac{n}{n \cdot (n-1)!} = \frac{1}{(n-1)!}
-\\]
+$$
 
 A typical application is the derivation of the mean of the [Poisson distribution](../poisson-distribution/) or the rewriting of binomial coefficients in a simpler form.
 
@@ -106,17 +106,17 @@ A typical application is the derivation of the mean of the [Poisson distribution
 
 ## Relationship between the factorial and the gamma function
 
-The gamma function can be seen as the natural extension of the factorial. Where the factorial is defined only on the [natural numbers](../natural-numbers), the gamma function is defined for every positive real value. For any \\(c \in \mathbb{R}^+\\), the gamma function is defined by the following integral:
+The gamma function can be seen as the natural extension of the factorial. Where the factorial is defined only on the [natural numbers](../natural-numbers), the gamma function is defined for every positive real value. For any $c \in \mathbb{R}^+$, the gamma function is defined by the following integral:
 
-\\[
-\Gamma\(c\) = \int_{0}^{+\infty} x^{c - 1} e^{-x} \\, dx
-\\]
+$$
+\Gamma(c) = \int_{0}^{+\infty} x^{c - 1} e^{-x} \, dx
+$$
 
 For integer arguments, the gamma function agrees with the factorial, as shown by the identity below:
 
-\\[
+$$
 \Gamma(n) = (n - 1)!
-\\]
+$$
 
 So the factorial can be seen as the discrete restriction of the gamma function to the natural numbers.
 
@@ -126,31 +126,31 @@ So the factorial can be seen as the discrete restriction of the gamma function t
 
 ## Stirling's approximation
 
-Stirling's approximation is used to estimate \\(n!\\) for large values of \\(n\\) when direct multiplication of all terms is not practical. It gives the following asymptotic form:
+Stirling's approximation is used to estimate $n!$ for large values of $n$ when direct multiplication of all terms is not practical. It gives the following asymptotic form:
 
-\\[
+$$
 n! \approx \sqrt{2\pi n} \left(\frac{n}{e}\right)^n
-\\]
+$$
 
-This approximation is needed because the factorial grows faster than both [polynomial](../polynomial-function/) and [exponential functions](../exponential-function/). Already for relatively small values, it can exceed \\(10^6\\), while \\(2^n\\) is still around \\(10^3\\).
+This approximation is needed because the factorial grows faster than both [polynomial](../polynomial-function/) and [exponential functions](../exponential-function/). Already for relatively small values, it can exceed $10^6$, while $2^n$ is still around $10^3$.
 
-| \\(n\\) | Polynomial \\(n^2\\) | Exponential \\(2^n\\) | Factorial \\(n!\\) |
+| $n$ | Polynomial $n^2$ | Exponential $2^n$ | Factorial $n!$ |
 |--------|---------------------|----------------------|-------------------|
 | 2 | 4 | 4 | 2 |
 | 5 | 25 | 32 | 120 |
 | 10 | 100 | 1,024 | 3,628,800 |
 | 15 | 225 | 32,768 | ~1.307 billion |
 
-The ratio between \\(n!\\) and its Stirling approximation tends to \\(1\\) as \\(n\\) grows without bound:
+The ratio between $n!$ and its Stirling approximation tends to $1$ as $n$ grows without bound:
 
-\\[
+$$
 \lim_{n \to \infty} \frac{n!}{\sqrt{2\pi n}\left(\dfrac{n}{e}\right)^n} = 1
-\\]
+$$
 
-This approximation becomes increasingly accurate as \\(n\\) grows. At \\(n = 10\\), the exact value \\(10! = 3{,}628{,}800\\) compares with Stirling's estimate of roughly \\(3{,}598{,}696\\), an error below \\(1\\%\\), while for \\(n > 100\\) the relative error drops under \\(0.1\\%\\). Another way to express the approximation is by introducing a correction term:
+This approximation becomes increasingly accurate as $n$ grows. At $n = 10$, the exact value $10! = 3{,}628{,}800$ compares with Stirling's estimate of roughly $3{,}598{,}696$, an error below $1\%$, while for $n > 100$ the relative error drops under $0.1\%$. Another way to express the approximation is by introducing a correction term:
 
-\\[
+$$
 n! \approx \sqrt{2\pi n} \left(\frac{n}{e}\right)^n \left(1 + \frac{1}{12n}\right)
-\\]
+$$
 
-> Stirling's approximation is used in the asymptotic analysis of [binomial coefficients](../binomial-coefficient/). For any base \\(a > 1\\), the factorial \\(n!\\) always dominates the [exponential](../exponential-function/) \\(a^n\\), that is, \\(\lim_{n \to \infty} a^n/n! = 0\\).
+> Stirling's approximation is used in the asymptotic analysis of [binomial coefficients](../binomial-coefficient/). For any base $a > 1$, the factorial $n!$ always dominates the [exponential](../exponential-function/) $a^n$, that is, $\lim_{n \to \infty} a^n/n! = 0$.

--- a/Notable-products.md
+++ b/Notable-products.md
@@ -7,9 +7,9 @@ Source: algebrica.org — CC BY-NC 4.0
 
 Notable products are identities describing the expansion or [factorisation](../factoring-ac-method/) of [polynomials](../polynomials) such as [binomials](../binomials) or [trinomials](../trinomials). They allow rewriting such expressions in a simpler form, and this is often what makes polynomial factorisation tractable in practice or what allows us to actually solve an [equation](../equations/).
 
-Consider for example the identity \\((a+b)^2 = a^2 + 2ab + b^2\\). A useful property is that, read from left to right, it gives us the expansion of the square, while read from right to left it gives us its factorisation.
+Consider for example the identity $(a+b)^2 = a^2 + 2ab + b^2$. A useful property is that, read from left to right, it gives us the expansion of the square, while read from right to left it gives us its factorisation.
 
-Most of the identities collected here are special cases of the [binomial theorem](../binomial-theorem/), which gives the expansion of \\((a+b)^n\\) for arbitrary non-negative integer \\(n\\). The square and the cube of a binomial are just the cases \\(n=2\\) and \\(n=3\\) of this general expansion. Other identities on this page, like the difference of two squares or the factorisation of \\(a^3 \pm b^3\\), cannot be obtained from the binomial theorem, although the underlying mechanism is essentially the same.
+Most of the identities collected here are special cases of the [binomial theorem](../binomial-theorem/), which gives the expansion of $(a+b)^n$ for arbitrary non-negative integer $n$. The square and the cube of a binomial are just the cases $n=2$ and $n=3$ of this general expansion. Other identities on this page, like the difference of two squares or the factorisation of $a^3 \pm b^3$, cannot be obtained from the binomial theorem, although the underlying mechanism is essentially the same.
 
 - - -
 
@@ -17,24 +17,24 @@ Most of the identities collected here are special cases of the [binomial theorem
 
 The square of a binomial is what we obtain when a binomial is multiplied by itself. There are two cases, depending on whether the two terms are added or subtracted:
 
-\\[
+$$
 \begin{align}
-(a+b)^2 &= a^2 + 2ab + b^2 \\\\[6pt]
+(a+b)^2 &= a^2 + 2ab + b^2 \\[6pt]
 (a-b)^2 &= a^2 - 2ab + b^2
 \end{align}
-\\]
+$$
 
-Working out the expansion of \\((a+b)^2\\), we obtain three terms:
+Working out the expansion of $(a+b)^2$, we obtain three terms:
 
-\\[
+$$
 \begin{align}
-(a+b)^2 &= (a+b)(a+b) \\\\[6pt]
-&= a^2 + ab + ab + b^2 \\\\[6pt]
+(a+b)^2 &= (a+b)(a+b) \\[6pt]
+&= a^2 + ab + ab + b^2 \\[6pt]
 &= a^2 + 2ab + b^2
 \end{align}
-\\]
+$$
 
-Two of them are the squares of \\(a\\) and \\(b\\), and the third one is twice their product. The case \\((a-b)^2\\) is analogous, with the only difference that the middle term comes out negative, since multiplying \\(a\\) by \\(-b\\) introduces a minus sign.
+Two of them are the squares of $a$ and $b$, and the third one is twice their product. The case $(a-b)^2$ is analogous, with the only difference that the middle term comes out negative, since multiplying $a$ by $-b$ introduces a minus sign.
 
 - - -
 
@@ -42,21 +42,21 @@ Two of them are the squares of \\(a\\) and \\(b\\), and the third one is twice t
 
 When we multiply a sum and a difference of the same two terms, the result is the difference of their squares:
 
-\\[
+$$
 a^2 - b^2 = (a+b)(a-b)
-\\]
+$$
 
 The product on the right-hand side expands as follows:
 
-\\[
+$$
 \begin{align}
-(a+b)(a-b) &= a(a-b) + b(a-b) \\\\[6pt]
-&= a^2 - ab + ab - b^2 \\\\[6pt]
+(a+b)(a-b) &= a(a-b) + b(a-b) \\[6pt]
+&= a^2 - ab + ab - b^2 \\[6pt]
 &= a^2 - b^2
 \end{align}
-\\]
+$$
 
-The terms \\(-ab\\) and \\(+ab\\) cancel out, so what is left is just \\(a^2 - b^2\\).
+The terms $-ab$ and $+ab$ cancel out, so what is left is just $a^2 - b^2$.
 
 - - -
 
@@ -64,69 +64,69 @@ The terms \\(-ab\\) and \\(+ab\\) cancel out, so what is left is just \\(a^2 - b
 
 When we multiply a binomial by itself three times, the result is one of the following two identities, depending on the sign between the two terms:
 
-\\[
+$$
 \begin{align}
-(a+b)^3 &= a^3 + 3a^2b + 3ab^2 + b^3 \\\\[6pt]
+(a+b)^3 &= a^3 + 3a^2b + 3ab^2 + b^3 \\[6pt]
 (a-b)^3 &= a^3 - 3a^2b + 3ab^2 - b^3
 \end{align}
-\\]
+$$
 
-Both are special cases of the [binomial theorem](../binomial-theorem/) with \\(n=3\\).
+Both are special cases of the [binomial theorem](../binomial-theorem/) with $n=3$.
 
 ---
 
-Closely related to the cube of a binomial are the sum and difference of two cubes, which work the other way around: they take an expression of the form \\(a^3 \pm b^3\\) and rewrite it as a product.
+Closely related to the cube of a binomial are the sum and difference of two cubes, which work the other way around: they take an expression of the form $a^3 \pm b^3$ and rewrite it as a product.
 
-\\[
+$$
 \begin{align}
-a^3 + b^3 &= (a+b)(a^2 - ab + b^2) \\\\[6pt]
+a^3 + b^3 &= (a+b)(a^2 - ab + b^2) \\[6pt]
 a^3 - b^3 &= (a-b)(a^2 + ab + b^2)
 \end{align}
-\\]
+$$
 
 The first identity can be verified by expanding the right-hand side:
 
-\\[
+$$
 \begin{align}
-(a+b)(a^2-ab+b^2) &= a^3 - a^2b + ab^2 + a^2b - ab^2 + b^3 \\\\[6pt]
+(a+b)(a^2-ab+b^2) &= a^3 - a^2b + ab^2 + a^2b - ab^2 + b^3 \\[6pt]
 &= a^3 + b^3
 \end{align}
-\\]
+$$
 
-The same procedure works for \\(a^3 - b^3\\):
+The same procedure works for $a^3 - b^3$:
 
-\\[
+$$
 \begin{align}
-(a-b)(a^2+ab+b^2) &= a^3 + a^2b + ab^2 - a^2b - ab^2 - b^3 \\\\[6pt]
+(a-b)(a^2+ab+b^2) &= a^3 + a^2b + ab^2 - a^2b - ab^2 - b^3 \\[6pt]
 &= a^3 - b^3
 \end{align}
-\\]
+$$
 
-In both cases the mixed terms cancel in pairs, and only the cubes \\(a^3\\) and \\(\pm b^3\\) survive.
+In both cases the mixed terms cancel in pairs, and only the cubes $a^3$ and $\pm b^3$ survive.
 
-> In the expansion of \\((a+b+c)^3\\), the coefficient \\(6\\) in the term \\(6abc\\) arises from the number of permutations of the three distinct factors \\(a\\), \\(b\\), \\(c\\), that is \\(3!=6\\). This is an instance of the multinomial theorem, which generalises the [binomial theorem](../binomial-theorem/) to sums of more than two terms.
+> In the expansion of $(a+b+c)^3$, the coefficient $6$ in the term $6abc$ arises from the number of permutations of the three distinct factors $a$, $b$, $c$, that is $3!=6$. This is an instance of the multinomial theorem, which generalises the [binomial theorem](../binomial-theorem/) to sums of more than two terms.
 
 - - -
 
 ## Notable products and the binomial theorem
 
-The square and the cube of a binomial both come from a more general formula, the [binomial theorem](../binomial-theorem/), which expands \\((a+b)^n\\) for any non-negative integer \\(n\\):
+The square and the cube of a binomial both come from a more general formula, the [binomial theorem](../binomial-theorem/), which expands $(a+b)^n$ for any non-negative integer $n$:
 
-\\[
+$$
 (a+b)^n = \sum_{k=0}^{n} \binom{n}{k} a^{n-k} b^{k}
-\\]
+$$
 
-The coefficients \\(\binom{n}{k}\\) are the [binomial coefficients](../binomial-coefficient/):
+The coefficients $\binom{n}{k}$ are the [binomial coefficients](../binomial-coefficient/):
 
-\\[
+$$
 \binom{n}{k} = \frac{n!}{k!(n-k)!}
-\\]
+$$
 
-If we now want to use this general formula to recover the cube of a binomial, we just need to set \\(n=3\\) and work out the four coefficients, which turn out to be \\(\binom{3}{0}=\binom{3}{3}=1\\) and \\(\binom{3}{1}=\binom{3}{2}=3\\). Substituting these numbers back into the formula, the expansion comes out as:
+If we now want to use this general formula to recover the cube of a binomial, we just need to set $n=3$ and work out the four coefficients, which turn out to be $\binom{3}{0}=\binom{3}{3}=1$ and $\binom{3}{1}=\binom{3}{2}=3$. Substituting these numbers back into the formula, the expansion comes out as:
 
-\\[
+$$
 (a+b)^3 = a^3 + 3a^2b + 3ab^2 + b^3
-\\]
+$$
 
 - - -
 
@@ -134,104 +134,104 @@ If we now want to use this general formula to recover the cube of a binomial, we
 
 Consider the following equation:
 
-\\[x^3 - 27 = 0\\]
+$$x^3 - 27 = 0$$
 
-Since \\(27 = 3^3\\), the left-hand side is a difference of two cubes. Applying the identity \\(a^3 - b^3 = (a-b)(a^2+ab+b^2)\\) with \\(a = x\\) and \\(b = 3\\), we factorise:
+Since $27 = 3^3$, the left-hand side is a difference of two cubes. Applying the identity $a^3 - b^3 = (a-b)(a^2+ab+b^2)$ with $a = x$ and $b = 3$, we factorise:
 
-\\[(x - 3)(x^2 + 3x + 9) = 0\\]
+$$(x - 3)(x^2 + 3x + 9) = 0$$
 
 The equation holds when either factor equals zero:
 
-\\[
+$$
 \begin{cases}
-x - 3 = 0 \\\\[0.5em]
+x - 3 = 0 \\[0.5em]
 x^2 + 3x + 9 = 0
 \end{cases}
-\\]
+$$
 
-The first case yields \\(x = 3\\) directly. For the second case, the [quadratic formula](../quadratic-formula/) is applied:
+The first case yields $x = 3$ directly. For the second case, the [quadratic formula](../quadratic-formula/) is applied:
 
-\\[
+$$
 \begin{align}
-x &= \frac{-3 \pm \sqrt{3^2 - 4(1)(9)}}{2(1)} \\\\
-  &= \frac{-3 \pm \sqrt{9 - 36}}{2} \\\\
+x &= \frac{-3 \pm \sqrt{3^2 - 4(1)(9)}}{2(1)} \\
+  &= \frac{-3 \pm \sqrt{9 - 36}}{2} \\
   &= \frac{-3 \pm \sqrt{-27}}{2}
 \end{align}
-\\]
+$$
 
-Because the discriminant \\(\Delta = -27 < 0\\), the two remaining solutions are [complex](../quadratic-equations-with-complex-solutions/). Substituting \\(\sqrt{-27} = 3i\sqrt{3}\\) gives:
+Because the discriminant $\Delta = -27 < 0$, the two remaining solutions are [complex](../quadratic-equations-with-complex-solutions/). Substituting $\sqrt{-27} = 3i\sqrt{3}$ gives:
 
-\\[x = \frac{-3 + 3i\sqrt{3}}{2} \qquad x = \frac{-3 - 3i\sqrt{3}}{2}\\]
+$$x = \frac{-3 + 3i\sqrt{3}}{2} \qquad x = \frac{-3 - 3i\sqrt{3}}{2}$$
 
 Therefore, by applying the expansion of the difference of two cubes, we were able to easily determine the solutions of the third-degree equation, which are:
 
-\\[
+$$
 x = 3, \quad x = \frac{-3 + 3i\sqrt{3}}{2}, \quad x = \frac{-3 - 3i\sqrt{3}}{2}
-\\]
+$$
 
 - - -
 
 ## Sum and difference of nth powers
 
-The identities seen so far cover only the cases \\(n=2\\) and \\(n=3\\). For a generic \\(n\\), the parity of the exponent decides whether \\(a^n+b^n\\) and \\(a^n-b^n\\) admit a factorisation.
+The identities seen so far cover only the cases $n=2$ and $n=3$. For a generic $n$, the parity of the exponent decides whether $a^n+b^n$ and $a^n-b^n$ admit a factorisation.
 
-The difference \\(a^n-b^n\\) factorises for any positive integer \\(n\\), with no parity restrictions, as:
+The difference $a^n-b^n$ factorises for any positive integer $n$, with no parity restrictions, as:
 
-\\[
+$$
 a^n-b^n = (a-b)(a^{n-1}+a^{n-2}b+a^{n-3}b^2+\cdots+ab^{n-2}+b^{n-1})
-\\]
+$$
 
-For the sum \\(a^n+b^n\\) when \\(n\\) is odd, an analogous factorisation does exist, with alternating signs in the second factor:
+For the sum $a^n+b^n$ when $n$ is odd, an analogous factorisation does exist, with alternating signs in the second factor:
 
-\\[
+$$
 a^n+b^n = (a+b)(a^{n-1}-a^{n-2}b+a^{n-3}b^2-\cdots-ab^{n-2}+b^{n-1})
-\\]
+$$
 
-When \\(n\\) is even, on the other hand, no such factorisation is available over \\(\mathbb{R}\\) in general. The expressions \\(a^2+b^2\\) and \\(a^4+b^4\\), for instance, are irreducible over the reals unless further structure is brought in.
+When $n$ is even, on the other hand, no such factorisation is available over $\mathbb{R}$ in general. The expressions $a^2+b^2$ and $a^4+b^4$, for instance, are irreducible over the reals unless further structure is brought in.
 
-> The factorisation of \\(a^n-b^n\\) is closely related to the structure of the \\(n\\)-th roots of unity in the [complex plane](../complex-numbers-introduction/). The [roots](../roots-of-a-polynomial/) of \\(a^n-b^n=0\\) are precisely \\(a/b=e^{2\pi i k/n}\\) for \\(k=0,1,\dots,n-1\\).
+> The factorisation of $a^n-b^n$ is closely related to the structure of the $n$-th roots of unity in the [complex plane](../complex-numbers-introduction/). The [roots](../roots-of-a-polynomial/) of $a^n-b^n=0$ are precisely $a/b=e^{2\pi i k/n}$ for $k=0,1,\dots,n-1$.
 
 ---
 
-The case of even \\(n\\) admits one exception, known as Sophie Germain's identity, which has some consequences in showing that certain integers of the form \\(n^4+4m^4\\) admit a non-trivial factorisation and are therefore not prime. The identity is:
+The case of even $n$ admits one exception, known as Sophie Germain's identity, which has some consequences in showing that certain integers of the form $n^4+4m^4$ admit a non-trivial factorisation and are therefore not prime. The identity is:
 
-\\[
+$$
 a^4+4b^4 = (a^2+2b^2+2ab)(a^2+2b^2-2ab)
-\\]
+$$
 
-At first sight this might seem like a contradiction, since we have just said that sums of even powers do not generally factorise over \\(\mathbb{R}\\). In this case the coefficient \\(4\\) makes it possible to complete the square and obtain:
+At first sight this might seem like a contradiction, since we have just said that sums of even powers do not generally factorise over $\mathbb{R}$. In this case the coefficient $4$ makes it possible to complete the square and obtain:
 
-\\[
+$$
 a^4+4b^4 = (a^2+2b^2)^2-(2ab)^2
-\\]
+$$
 
 In this way the expression is a difference of two squares, and the factorisation follows from the standard identity.
 
-> The identities for \\(a^n \pm b^n\\) are related to Newton's identities, which express power sums \\(p_k=a^k+b^k\\) in terms of the elementary symmetric polynomials \\(e_1=a+b\\) and \\(e_2=ab\\).
+> The identities for $a^n \pm b^n$ are related to Newton's identities, which express power sums $p_k=a^k+b^k$ in terms of the elementary symmetric polynomials $e_1=a+b$ and $e_2=ab$.
 
 - - -
-- 
+
 ## Example 2
 
 Let's consider the following expression:
 
-\\[a^4 + b^4\\]
+$$a^4 + b^4$$
 
-Since \\(n = 4\\) is even, \\(a^4 + b^4\\) does not factorise over \\(\mathbb{R}\\) using the sum of nth powers formula, which applies only for odd \\(n\\).
+Since $n = 4$ is even, $a^4 + b^4$ does not factorise over $\mathbb{R}$ using the sum of nth powers formula, which applies only for odd $n$.
 
 However, it admits the following factorisation:
 
-\\[a^4 + b^4 = (a^2 + \sqrt{2}\\,ab + b^2)(a^2 - \sqrt{2}\\,ab + b^2)\\] 
+$$a^4 + b^4 = (a^2 + \sqrt{2}\,ab + b^2)(a^2 - \sqrt{2}\,ab + b^2)$$ 
 
 The factorisation can be verified by expanding the right-hand side:
 
-\\[
+$$
 \begin{align}
-(a^2 + \sqrt{2}\\,ab + b^2)(a^2 - \sqrt{2}\\,ab + b^2) &= (a^2 + b^2)^2 - (\sqrt{2}\\,ab)^2 \\\\
-&= a^4 + 2a^2b^2 + b^4 - 2a^2b^2 \\\\
+(a^2 + \sqrt{2}\,ab + b^2)(a^2 - \sqrt{2}\,ab + b^2) &= (a^2 + b^2)^2 - (\sqrt{2}\,ab)^2 \\
+&= a^4 + 2a^2b^2 + b^4 - 2a^2b^2 \\
 &= a^4 + b^4
 \end{align}
-\\]
+$$
 
 - - -
 
@@ -239,17 +239,17 @@ The factorisation can be verified by expanding the right-hand side:
 
 | | |
 |---|---|
-| \\[(a + b)^2\\] | \\[a^2 + 2ab + b^2\\] |
-| \\[(a - b)^2\\] | \\[a^2 - 2ab + b^2\\] |
-| \\[a^2 - b^2\\] | \\[(a + b)(a - b)\\] |
-| \\[(a + b)^3\\] | \\[a^3 + 3a^2b + 3ab^2 + b^3\\] |
-| \\[(a - b)^3\\] | \\[a^3 - 3a^2b + 3ab^2 - b^3\\] |
-| \\[a^3 + b^3\\] | \\[(a + b)(a^2 - ab + b^2)\\] |
-| \\[a^3 - b^3\\] | \\[(a - b)(a^2 + ab + b^2)\\] |
-| \\[a^n + b^n \quad (n \text{ odd})\\] | \\[(a + b)(a^{n-1} - a^{n-2}b + \cdots + b^{n-1})\\] |
-| \\[a^n - b^n\\] | \\[(a - b)(a^{n-1} + a^{n-2}b + \cdots + b^{n-1})\\] |
-| \\[a^{2n} - b^{2n}\\] | \\[(a^n - b^n)(a^n + b^n)\\] |
-| \\[a^4 - b^4\\] | \\[(a - b)(a + b)(a^2 + b^2)\\] |
-| \\[a^4 + b^4\\] | \\[(a^2 + \sqrt{2}\\,ab + b^2)(a^2 - \sqrt{2}\\,ab + b^2)\\] |
-| \\[(a + b + c)^2\\] | \\[a^2 + b^2 + c^2 + 2(ab + ac + bc)\\] |
-| \\[(a + b + c)^3\\] | \\[a^3 + b^3 + c^3 + 3(a^2b + a^2c + b^2a + b^2c + c^2a + c^2b) + 6abc\\] |
+| $(a + b)^2$ | $a^2 + 2ab + b^2$ |
+| $(a - b)^2$ | $a^2 - 2ab + b^2$ |
+| $a^2 - b^2$ | $(a + b)(a - b)$ |
+| $(a + b)^3$ | $a^3 + 3a^2b + 3ab^2 + b^3$ |
+| $(a - b)^3$ | $a^3 - 3a^2b + 3ab^2 - b^3$ |
+| $a^3 + b^3$ | $(a + b)(a^2 - ab + b^2)$ |
+| $a^3 - b^3$ | $(a - b)(a^2 + ab + b^2)$ |
+| $a^n + b^n \quad (n \text{ odd})$ | $(a + b)(a^{n-1} - a^{n-2}b + \cdots + b^{n-1})$ |
+| $a^n - b^n$ | $(a - b)(a^{n-1} + a^{n-2}b + \cdots + b^{n-1})$ |
+| $a^{2n} - b^{2n}$ | $(a^n - b^n)(a^n + b^n)$ |
+| $a^4 - b^4$ | $(a - b)(a + b)(a^2 + b^2)$ |
+| $a^4 + b^4$ | $(a^2 + \sqrt{2}\,ab + b^2)(a^2 - \sqrt{2}\,ab + b^2)$ |
+| $(a + b + c)^2$ | $a^2 + b^2 + c^2 + 2(ab + ac + bc)$ |
+| $(a + b + c)^3$ | $a^3 + b^3 + c^3 + 3(a^2b + a^2c + b^2a + b^2c + c^2a + c^2b) + 6abc$ |

--- a/Sets.md
+++ b/Sets.md
@@ -18,7 +18,7 @@ The previous notation defines $A$ as the set of all integers $x$ such that $x > 
 $$
 A = \{5, 6, 7, 8\}
 $$
-The empty set is the set that contain no elements, is denoted by $\emptyset$ or $\{\}$ and serves a role in set theory analogous to that of zero in arithmetic.
+The empty set is the set that contains no elements and is denoted by $\emptyset$ or $\{\}$ and serves a role in set theory analogous to that of zero in arithmetic.
 
 - - -
 

--- a/Sets.md
+++ b/Sets.md
@@ -4,27 +4,27 @@ Source: algebrica.org — CC BY-NC 4.0
 
 ## Introduction
 
-A set is a collection of objects called elements that are considered as a whole. They are represented by uppercase letters \\(A\\), \\(B\\), \\(C\\), and their elements by lowercase letters. The notation \\(x \in A\\) indicates that an object \\(x\\) belongs to the set \\(A\\) while \\(x \notin A\\) indicates that \\(x\\) is not an element of \\(A\\). For any given object, it is always possible to determine unambiguously if the object belongs to the collection or not.
+A set is a collection of objects called elements that are considered as a whole. They are represented by uppercase letters $A$, $B$, $C$, and their elements by lowercase letters. The notation $x \in A$ indicates that an object $x$ belongs to the set $A$ while $x \notin A$ indicates that $x$ is not an element of $A$. For any given object, it is always possible to determine unambiguously if the object belongs to the collection or not.
 A set can be described by enumeration or by the set-builder notation.
 Enumeration consists of explicitly listing each element of the set and is practical when the cardinality of the set is finite or small:
-\\[
-A = \\{a_1, a_2, a_3, a_4\\}
-\\]
+$$
+A = \{a_1, a_2, a_3, a_4\}
+$$
 When the elements are numerous or infinite, set-builder notation becomes preferable. In this case the set is described by the property that each element must satisfy in order to belong to it:
-\\[
-A = \\{ x \in \mathbb{Z} \mid x > 4, \\, x \leq 8 \\}
-\\]
-The previous notation defines \\(A\\) as the set of all integers \\(x\\) such that \\(x > 4\\) and \\(x \leq 8\\), that is, the set of the following integers:
-\\[
-A = \\{5, 6, 7, 8\\}
-\\]
-The empty set is the set that contain no elements, is denoted by \\(\emptyset\\) or \\(\\{\\}\\) and serves a role in set theory analogous to that of zero in arithmetic.
+$$
+A = \{ x \in \mathbb{Z} \mid x > 4, \, x \leq 8 \}
+$$
+The previous notation defines $A$ as the set of all integers $x$ such that $x > 4$ and $x \leq 8$, that is, the set of the following integers:
+$$
+A = \{5, 6, 7, 8\}
+$$
+The empty set is the set that contain no elements, is denoted by $\emptyset$ or $\{\}$ and serves a role in set theory analogous to that of zero in arithmetic.
 
 - - -
 
 ## The universal set
 
-Often, we specify a main collection containing all objects we are considering, called the universal set and it is written as \\(U\\). All sets in this context are subsets of \\(U\\). The choice of \\(U\\) depends on the situation. In elementary number theory, one often works with \\(U = \mathbb{Z}\\), whereas in real analysis the usual choice is \\(U = \mathbb{R}\\).
+Often, we specify a main collection containing all objects we are considering, called the universal set and it is written as $U$. All sets in this context are subsets of $U$. The choice of $U$ depends on the situation. In elementary number theory, one often works with $U = \mathbb{Z}$, whereas in real analysis the usual choice is $U = \mathbb{R}$.
 
 > The universal set is a way to define the concept of set complement unambiguously as illustrated in the section on set operations.
 
@@ -32,39 +32,39 @@ Often, we specify a main collection containing all objects we are considering, c
 
 ## Cardinality of finite sets
 
-The cardinality of a set \\(A\\), denoted \\(|A|\\), is the number of elements the set contains. The cardinality can be measured in different cases, as follows.
+The cardinality of a set $A$, denoted $|A|$, is the number of elements the set contains. The cardinality can be measured in different cases, as follows.
 
-The empty set has cardinality \\(|\emptyset| = 0\\).
+The empty set has cardinality $|\emptyset| = 0$.
 
 Two finite sets have the same cardinality if and only if they contain the same number of elements.
 
-The cardinality of the power set of a finite set \\(A\\) with \\(n\\) elements is given by:
+The cardinality of the power set of a finite set $A$ with $n$ elements is given by:
 
-\\[
+$$
 |\mathcal{P}(A)| = 2^n
-\\]
+$$
 
-The cardinality of the Cartesian product of two finite sets \\(A\\) and \\(B\\) is given by:
+The cardinality of the Cartesian product of two finite sets $A$ and $B$ is given by:
 
-\\[
+$$
 |A \times B| = |A| \cdot |B|
-\\]
+$$
 
-In this case each element of \\(A\\) can be paired with every element of \\(B\\), producing \\(|A| \cdot |B|\\) ordered pairs.
+In this case each element of $A$ can be paired with every element of $B$, producing $|A| \cdot |B|$ ordered pairs.
 
-The cardinality of the union of two sets \\(A\\) and \\(B\\) is given by:
+The cardinality of the union of two sets $A$ and $B$ is given by:
 
-\\[
+$$
 |A \cup B| = |A| + |B| - |A \cap B|
-\\]
+$$
 
-The previous expression is known as the inclusion-exclusion principle, which ensures that elements common to both sets are counted once. Every element of \\(A \cup B\\) appears in the sum \\(|A| + |B|\\). Elements lying in \\(A \cap B\\) are counted twice so the term is subtracted to assure the correct count.
+The previous expression is known as the inclusion-exclusion principle, which ensures that elements common to both sets are counted once. Every element of $A \cup B$ appears in the sum $|A| + |B|$. Elements lying in $A \cap B$ are counted twice so the term is subtracted to assure the correct count.
 
 The principle can also be extended to three sets, as expressed by:
 
-\\[
+$$
 |A \cup B \cup C| = |A| + |B| + |C| - |A \cap B| - |A \cap C| - |B \cap C| + |A \cap B \cap C|
-\\]
+$$
 
 In this case:
 
@@ -76,46 +76,46 @@ In this case:
 
 ## Subsets and power sets
 
-In this section, we examine the definitions of subset and power set. Intuitively, the former are sets whose elements all belong to another set, while the latter are sets whose elements are themselves subsets of a given set. A set \\(A\\) is a subset of \\(B\\) if every element of \\(A\\) is also an element of \\(B\\):
+In this section, we examine the definitions of subset and power set. Intuitively, the former are sets whose elements all belong to another set, while the latter are sets whose elements are themselves subsets of a given set. A set $A$ is a subset of $B$ if every element of $A$ is also an element of $B$:
 
-\\[
-A \subseteq B \iff \forall \\, x, \\, x \in A \rightarrow x \in B
-\\]
+$$
+A \subseteq B \iff \forall \, x, \, x \in A \rightarrow x \in B
+$$
 
 Two sets are equal if and only if each is contained in the other, which is the standard way to establish set equality in mathematics:
 
-\\[
+$$
 A = B \iff A \subseteq B \text{ and } B \subseteq A
-\\]
+$$
 
-If \\(A \subseteq B\\) and \\(A \neq B\\), then \\(A\\) is a proper subset of \\(B\\), denoted \\(A \subsetneq B\\) and in this case, there exists at least one element in \\(B\\) that does not belong to \\(A\\). The empty set is a subset of every set. The inclusion \\(\emptyset \subseteq A\\) holds for any set \\(A\\), because the implication \\(x \in \emptyset \Rightarrow x \in A\\) is vacuously true.
+If $A \subseteq B$ and $A \neq B$, then $A$ is a proper subset of $B$, denoted $A \subsetneq B$ and in this case, there exists at least one element in $B$ that does not belong to $A$. The empty set is a subset of every set. The inclusion $\emptyset \subseteq A$ holds for any set $A$, because the implication $x \in \emptyset \Rightarrow x \in A$ is vacuously true.
 
-The power set of a set \\(A\\) is the set of all subsets of \\(A\\) and is denoted \\(\mathcal{P}(A)\\). It includes the empty set \\(\emptyset\\) and the set \\(A\\) itself. If \\(A\\) has \\(n\\) elements, then \\(\mathcal{P}(A)\\) has \\(2^n\\) elements. For example, if \\(A = \\{a, b, c\\}\\), then the power set contains \\(2^3 = 8\\) elements:
+The power set of a set $A$ is the set of all subsets of $A$ and is denoted $\mathcal{P}(A)$. It includes the empty set $\emptyset$ and the set $A$ itself. If $A$ has $n$ elements, then $\mathcal{P}(A)$ has $2^n$ elements. For example, if $A = \{a, b, c\}$, then the power set contains $2^3 = 8$ elements:
 
-\\[
-\mathcal{P}(A) = \\{\emptyset, \\, \\{a\\}, \\, \\{b\\}, \\, \\{c\\}, \\, \\{a,b\\}, \\, \\{a,c\\}, \\, \\{b,c\\}, \\, \\{a,b,c\\}\\}
-\\]
+$$
+\mathcal{P}(A) = \{\emptyset, \, \{a\}, \, \{b\}, \, \{c\}, \, \{a,b\}, \, \{a,c\}, \, \{b,c\}, \, \{a,b,c\}\}
+$$
 
 - - -
 
 ## Partitions
 
-A partition of a set \\(A\\) is a family of non-empty subsets \\(\\{A_i\\}_{i \in I}\\) that do not overlap and cover the whole of \\(A\\), which means the following conditions must hold:
+A partition of a set $A$ is a family of non-empty subsets $\{A_i\}_{i \in I}$ that do not overlap and cover the whole of $A$, which means the following conditions must hold:
 
-\\[
+$$
 \begin{align}
-&A_i \neq \emptyset \quad \forall \\, i \in I \\\\[6pt]
-&A_i \cap A_j = \emptyset \quad \forall \\, i \neq j \\\\[6pt]
+&A_i \neq \emptyset \quad \forall \, i \in I \\[6pt]
+&A_i \cap A_j = \emptyset \quad \forall \, i \neq j \\[6pt]
 & \bigcup_{i \in I} A_i = A
 \end{align}
-\\]
+$$
 
-The subsets \\(A_i\\) are called the blocks of the partition and each element of \\(A\\) belongs to exactly one of them. A simple example is the set of [integers](../integers/) \\(\mathbb{Z}\\), which can be partitioned into the set of even integers and the set of odd integers, since these two blocks are non-empty, disjoint, and together cover the whole of \\(\mathbb{Z}\\).
+The subsets $A_i$ are called the blocks of the partition and each element of $A$ belongs to exactly one of them. A simple example is the set of [integers](../integers/) $\mathbb{Z}$, which can be partitioned into the set of even integers and the set of odd integers, since these two blocks are non-empty, disjoint, and together cover the whole of $\mathbb{Z}$.
 
-Partitions are related to equivalence relations. Given an equivalence relation on \\(A\\) we have:
+Partitions are related to equivalence relations. Given an equivalence relation on $A$ we have:
 
-* The equivalence classes it induces form a partition of \\(A\\).
-* Any partition of \\(A\\) defines an equivalence relation by declaring two elements equivalent whenever they belong to the same block.
+* The equivalence classes it induces form a partition of $A$.
+* Any partition of $A$ defines an equivalence relation by declaring two elements equivalent whenever they belong to the same block.
 
 - - -
 
@@ -123,268 +123,268 @@ Partitions are related to equivalence relations. Given an equivalence relation o
 
 Set operations generate new sets by combining the elements of different sets in different ways. The main operations are union, intersection, complement, and difference, which are illustrated below.
 
-The union of \\(A\\) and \\(B\\) is the set of all elements that belong to at least one of the two sets. Elements common to \\(A\\) and \\(B\\) are listed only once, since sets do not allow repetitions.
+The union of $A$ and $B$ is the set of all elements that belong to at least one of the two sets. Elements common to $A$ and $B$ are listed only once, since sets do not allow repetitions.
 
-\\[
-A \cup B = \\{x \mid x \in A \text{ or } x \in B\\}
-\\]
+$$
+A \cup B = \{x \mid x \in A \text{ or } x \in B\}
+$$
 
-The intersection of \\(A\\) and \\(B\\) is the set of elements that belong to both sets:
+The intersection of $A$ and $B$ is the set of elements that belong to both sets:
 
-\\[
-A \cap B = \\{x \mid x \in A \text{ and } x \in B\\}
-\\]
+$$
+A \cap B = \{x \mid x \in A \text{ and } x \in B\}
+$$
 
-If \\(A \cap B = \emptyset\\), the two sets are disjoint and share no elements.
+If $A \cap B = \emptyset$, the two sets are disjoint and share no elements.
 
-The complement of \\(A\\) with respect to a universal set \\(U\\) is the set of all elements in \\(U\\) that do not belong to \\(A\\). It is written as:
+The complement of $A$ with respect to a universal set $U$ is the set of all elements in $U$ that do not belong to $A$. It is written as:
 
-\\[
-A^c = \\{x \in U \mid x \notin A\\}
-\\]
+$$
+A^c = \{x \in U \mid x \notin A\}
+$$
 
-Another way to represent the complement of \\(A\\) is \\(\overline{A}\\) or \\(U \setminus A\\). A single set may yield different complements when \\(U\\) changes, since the elements of the complement vary with the universal set we pick.
+Another way to represent the complement of $A$ is $\overline{A}$ or $U \setminus A$. A single set may yield different complements when $U$ changes, since the elements of the complement vary with the universal set we pick.
 
-The difference of \\(A\\) and \\(B\\), \\(A \setminus B\\), is the set of elements that belong to \\(A\\) but not to \\(B\\):
+The difference of $A$ and $B$, $A \setminus B$, is the set of elements that belong to $A$ but not to $B$:
 
-\\[
-A \setminus B = \\{x \mid x \in A \text{ and } x \notin B\\}
-\\]
+$$
+A \setminus B = \{x \mid x \in A \text{ and } x \notin B\}
+$$
 
-The relation \\(A \setminus B \neq B \setminus A\\) holds, since the difference between sets is not a commutative operation. For any universal set that contains both \\(A\\) and \\(B\\) the identity \\(A \setminus B = A \cap B^c\\) holds, linking the difference to the complement.
+The relation $A \setminus B \neq B \setminus A$ holds, since the difference between sets is not a commutative operation. For any universal set that contains both $A$ and $B$ the identity $A \setminus B = A \cap B^c$ holds, linking the difference to the complement.
 
-The symmetric difference of \\(A\\) and \\(B\\), \\(A \triangle B\\), is the set of elements that belong to one of the two sets but not to both:
+The symmetric difference of $A$ and $B$, $A \triangle B$, is the set of elements that belong to one of the two sets but not to both:
 
-\\[
+$$
 A \triangle B = (A \setminus B) \cup (B \setminus A)
-\\]
+$$
 
 An equivalent representation is given by the following expression:
 
-\\[
+$$
 A \triangle B = (A \cup B) \setminus (A \cap B)
-\\]
+$$
 
-The symmetric difference is commutative and associative, and satisfies \\(A \triangle A = \emptyset\\) and \\(A \triangle \emptyset = A\\). Together with intersection, it gives the collection of all subsets of a given set the structure of a boolean [ring](../rings/).
+The symmetric difference is commutative and associative, and satisfies $A \triangle A = \emptyset$ and $A \triangle \emptyset = A$. Together with intersection, it gives the collection of all subsets of a given set the structure of a boolean [ring](../rings/).
 
 - - -
 
 ## Properties of set operations
 
-The set operations satisfy a series of identities that form the foundation of Boolean algebra and hold for any sets \\(A\\), \\(B\\), and \\(C\\) within a universal set \\(U\\). Union and intersection are commutative operations. The order in which two sets are combined does not affect the result.
+The set operations satisfy a series of identities that form the foundation of Boolean algebra and hold for any sets $A$, $B$, and $C$ within a universal set $U$. Union and intersection are commutative operations. The order in which two sets are combined does not affect the result.
 
-\\[
+$$
 \begin{align}
-A \cup B &= B \cup A \\\\[6pt]
+A \cup B &= B \cup A \\[6pt]
 A \cap B &= B \cap A
 \end{align}
-\\]
+$$
 
 Both operations are also associative, meaning that when three sets are combined, the grouping of the operands is irrelevant.
 
-\\[
+$$
 \begin{align}
-(A \cup B) \cup C &= A \cup (B \cup C) \\\\[6pt]
+(A \cup B) \cup C &= A \cup (B \cup C) \\[6pt]
 (A \cap B) \cap C &= A \cap (B \cap C)
 \end{align}
-\\]
+$$
 
 Union and intersection distribute over each other, in a manner analogous to the distributive law of arithmetic.
 
-\\[
+$$
 \begin{align}
-A \cap (B \cup C) &= (A \cap B) \cup (A \cap C) \\\\[6pt]
+A \cap (B \cup C) &= (A \cap B) \cup (A \cap C) \\[6pt]
 A \cup (B \cap C) &= (A \cup B) \cap (A \cup C)
 \end{align}
-\\]
+$$
 
 The empty set and the universal set act as the identity element respectively for union and for intersection. Combining any set with either of them brings back the original set.
 
-\\[
+$$
 \begin{align}
-A \cup \emptyset &= A \\\\[6pt]
+A \cup \emptyset &= A \\[6pt]
 A \cap U &= A
 \end{align}
-\\]
+$$
 
 The empty set annihilates intersection and the universal set annihilates union. Combining any set with these elements gives back the absorbing element rather than the original set:
 
-\\[
+$$
 \begin{align}
-A \cap \emptyset &= \emptyset \\\\[6pt]
+A \cap \emptyset &= \emptyset \\[6pt]
 A \cup U &= U
 \end{align}
-\\]
+$$
 
-Each element of \\(U\\) lies either in \\(A\\) or in its complement, never in both, and applying the complement operation a second time, in succession, brings the original set back:
+Each element of $U$ lies either in $A$ or in its complement, never in both, and applying the complement operation a second time, in succession, brings the original set back:
 
-\\[
+$$
 \begin{align}
-A \cup A^c &= U \\\\[6pt]
-A \cap A^c &= \emptyset \\\\[6pt]
+A \cup A^c &= U \\[6pt]
+A \cap A^c &= \emptyset \\[6pt]
 (A^c)^c &= A
 \end{align}
-\\]
+$$
 
 ## De Morgan's laws
 
 De Morgan's laws are algebraic identities that describe how union and intersection behave under the complement operation. These identities allow set expressions to be rewritten in equivalent forms, helping to simplify the operations.
 
-\\[
+$$
 \begin{align}
-(A \cup B)^c &= A^c \cap B^c \\\\[6pt]
+(A \cup B)^c &= A^c \cap B^c \\[6pt]
 (A \cap B)^c &= A^c \cup B^c
 \end{align}
-\\]
+$$
 
-The first law states that the complement of a union equals the intersection of the complements. An element is missing from \\(A \cup B\\) only when it is missing from both \\(A\\) and \\(B\\), and this is the same as belonging to both \\(A^c\\) and \\(B^c\\).
+The first law states that the complement of a union equals the intersection of the complements. An element is missing from $A \cup B$ only when it is missing from both $A$ and $B$, and this is the same as belonging to both $A^c$ and $B^c$.
 
-The second law states that an element is not in the intersection \\(A \cap B\\) when it is missing from at least one of the two sets, and this places it in \\(A^c \cup B^c\\).
+The second law states that an element is not in the intersection $A \cap B$ when it is missing from at least one of the two sets, and this places it in $A^c \cup B^c$.
 
-These laws generalise to arbitrary finite collections of sets. For example, for the sets \\(A_1, A_2, \ldots, A_n\\) we have the following relations:
+These laws generalise to arbitrary finite collections of sets. For example, for the sets $A_1, A_2, \ldots, A_n$ we have the following relations:
 
-\\[
+$$
 \begin{align}
-\left(\bigcup_{i=1}^{n} A_i\right)^c &= \bigcap_{i=1}^{n} A_i^c \\\\[6pt]
+\left(\bigcup_{i=1}^{n} A_i\right)^c &= \bigcap_{i=1}^{n} A_i^c \\[6pt]
 \left(\bigcap_{i=1}^{n} A_i\right)^c &= \bigcup_{i=1}^{n} A_i^c
 \end{align}
-\\]
+$$
 
 There exists a relation between the algebraic structure of sets and that of the logical connectives of [propositional logic](../propositional-logic/). De Morgan's laws correspond, in fact, to the following equivalences in propositional logic:
 
-\\[
+$$
 \neg(P \lor Q) \equiv \neg P \land \neg Q
-\\]
+$$
 
-\\[
+$$
 \neg(P \land Q) \equiv \neg P \lor \neg Q
-\\]
+$$
 
 - - -
 
 ## Example
 
-Let \\(U = \\{1, 2, 3, 4, 5, 6, 7, 8, 9, 10\\}\\) be the universal set, and define the following two subsets:
+Let $U = \{1, 2, 3, 4, 5, 6, 7, 8, 9, 10\}$ be the universal set, and define the following two subsets:
 
-\\[
+$$
 \begin{align}
-A &= \\{1, 2, 3, 4, 6\\} \\\\[6pt]
-B &= \\{2, 4, 6, 8, 10\\}
+A &= \{1, 2, 3, 4, 6\} \\[6pt]
+B &= \{2, 4, 6, 8, 10\}
 \end{align}
-\\]
+$$
 
 The union and intersection of the two sets are computed from the definitions:
 
-\\[
+$$
 \begin{align}
-A \cup B &= \\{1, 2, 3, 4, 6, 8, 10\\} \\\\[6pt]
-A \cap B &= \\{2, 4, 6\\}
+A \cup B &= \{1, 2, 3, 4, 6, 8, 10\} \\[6pt]
+A \cap B &= \{2, 4, 6\}
 \end{align}
-\\]
+$$
 
-The complements with respect to \\(U\\) are the elements excluded from each set:
+The complements with respect to $U$ are the elements excluded from each set:
 
-\\[
+$$
 \begin{align}
-A^c &= \\{5, 7, 8, 9, 10\\} \\\\[6pt]
-B^c &= \\{1, 3, 5, 7, 9\\}
+A^c &= \{5, 7, 8, 9, 10\} \\[6pt]
+B^c &= \{1, 3, 5, 7, 9\}
 \end{align}
-\\]
+$$
 
 We now verify the first De Morgan law. The complement of the union is:
 
-\\[
-(A \cup B)^c = U \setminus (A \cup B) = \\{5, 7, 9\\}
-\\]
+$$
+(A \cup B)^c = U \setminus (A \cup B) = \{5, 7, 9\}
+$$
 
 The intersection of the complements gives:
 
-\\[
+$$
 \begin{align}
-A^c \cap B^c &= \\{5, 7, 8, 9, 10\\} \cap \\{1, 3, 5, 7, 9\\} \\\\[6pt]
-&= \\{5, 7, 9\\}
+A^c \cap B^c &= \{5, 7, 8, 9, 10\} \cap \{1, 3, 5, 7, 9\} \\[6pt]
+&= \{5, 7, 9\}
 \end{align}
-\\]
+$$
 
 The two sets coincide, confirming the first De Morgan law. We now verify the inclusion-exclusion principle using cardinalities.
 
-\\[
+$$
 |A| = 5 \quad |B| = 5 \quad |A \cap B| = 3
-\\]
+$$
 
-\\[
+$$
 |A \cup B| = 5 + 5 - 3 = 7
-\\]
+$$
 
-A direct count of the elements of \\(A \cup B = \\{1, 2, 3, 4, 6, 8, 10\\}\\) confirms that \\(|A \cup B| = 7\\).
+A direct count of the elements of $A \cup B = \{1, 2, 3, 4, 6, 8, 10\}$ confirms that $|A \cup B| = 7$.
 
 Lastly, we compute the symmetric difference and check how it relates to the other operations.
 
-\\[
+$$
 A \triangle B = (A \setminus B) \cup (B \setminus A)
-\\]
+$$
 
-The two differences are \\(A \setminus B = \\{1, 3\\}\\) and \\(B \setminus A = \\{8, 10\\}\\), giving:
+The two differences are $A \setminus B = \{1, 3\}$ and $B \setminus A = \{8, 10\}$, giving:
 
-\\[
-A \triangle B = \\{1, 3, 8, 10\\}
-\\]
+$$
+A \triangle B = \{1, 3, 8, 10\}
+$$
 
 The same result can be obtained through the equivalent characterisation that uses union and intersection:
 
-\\[
+$$
 \begin{align}
-(A \cup B) \setminus (A \cap B) &= \\{1, 2, 3, 4, 6, 8, 10\\} \setminus \\{2, 4, 6\\} \\\\[6pt]
-&= \\{1, 3, 8, 10\\}
+(A \cup B) \setminus (A \cap B) &= \{1, 2, 3, 4, 6, 8, 10\} \setminus \{2, 4, 6\} \\[6pt]
+&= \{1, 3, 8, 10\}
 \end{align}
-\\]
+$$
 
 - - -
 
 ## Cartesian product
 
-Given two sets \\(A\\) and \\(B\\), the Cartesian product \\(A \times B\\) is the set of all ordered pairs \\((a, b)\\) such that \\(a\\) belongs to \\(A\\) and \\(b\\) belongs to \\(B\\):
+Given two sets $A$ and $B$, the Cartesian product $A \times B$ is the set of all ordered pairs $(a, b)$ such that $a$ belongs to $A$ and $b$ belongs to $B$:
 
-\\[
-A \times B = \\{(a, b) \mid a \in A, \\, b \in B\\}
-\\]
+$$
+A \times B = \{(a, b) \mid a \in A, \, b \in B\}
+$$
 
-An ordered pair is asymmetric: \\((a, b)\\) differs from \\((b, a)\\) if \\(a\\) and \\(b\\) are not the same. Two ordered pairs are equal if and only if their corresponding components are equal, as expressed by the following condition:
+An ordered pair is asymmetric: $(a, b)$ differs from $(b, a)$ if $a$ and $b$ are not the same. Two ordered pairs are equal if and only if their corresponding components are equal, as expressed by the following condition:
 
-\\[
+$$
 (a, b) = (a', b') \iff a = a' \text{ and } b = b'
-\\]
+$$
 
-In general \\(A \times B\\) and \\(B \times A\\) are not the same. If set \\(A\\) contains \\(m\\) elements and set \\(B\\) contains \\(n\\) elements, then \\(A \times B\\) contains \\(mn\\) elements. For example \\(\mathbb{R} \times \mathbb{R}\\), which represents the set of all pairs of [real numbers](../real-numbers/) corresponding to the Cartesian plane, contains \\(\mathbb{R}^2\\) elements.
+In general $A \times B$ and $B \times A$ are not the same. If set $A$ contains $m$ elements and set $B$ contains $n$ elements, then $A \times B$ contains $mn$ elements. For example $\mathbb{R} \times \mathbb{R}$, which represents the set of all pairs of [real numbers](../real-numbers/) corresponding to the Cartesian plane, contains $\mathbb{R}^2$ elements.
 
-Given the sets \\(A_1, A_2, \ldots, A_n\\), their Cartesian product is the set of all ordered \\(n\\)-tuples:
+Given the sets $A_1, A_2, \ldots, A_n$, their Cartesian product is the set of all ordered $n$-tuples:
 
-\\[
-A_1 \times A_2 \times \cdots \times A_n = \\{(a_1, a_2, \ldots, a_n) \mid a_i \in A_i \\, \text{for each } \\, i = 1, \ldots, n\\}
-\\]
+$$
+A_1 \times A_2 \times \cdots \times A_n = \{(a_1, a_2, \ldots, a_n) \mid a_i \in A_i \, \text{for each } \, i = 1, \ldots, n\}
+$$
 
-An \\(n\\)-tuple \\((a_1, \ldots, a_n)\\) is an ordered sequence of \\(n\\) elements, and two \\(n\\)-tuples are equal if and only if all corresponding components are equal. If all sets are identical, that is, \\(A_i = A\\) for every \\(i\\), the product is \\(A^n\\). The space \\(\mathbb{R}^n\\) is the \\(n\\)-fold Cartesian product of \\(\mathbb{R}\\) with itself, and its elements are \\(n\\)-tuples of real numbers.
+An $n$-tuple $(a_1, \ldots, a_n)$ is an ordered sequence of $n$ elements, and two $n$-tuples are equal if and only if all corresponding components are equal. If all sets are identical, that is, $A_i = A$ for every $i$, the product is $A^n$. The space $\mathbb{R}^n$ is the $n$-fold Cartesian product of $\mathbb{R}$ with itself, and its elements are $n$-tuples of real numbers.
 
 - - -
 
 ## The ordered pair
 
-The discussion so far has treated the ordered pair \\((a, b)\\) as an intuitive notion, namely a pair of objects in which the first component is \\(a\\) and the second is \\(b\\). In formal terms, the ordered pair can be defined set-theoretically as a set containing two elements:
+The discussion so far has treated the ordered pair $(a, b)$ as an intuitive notion, namely a pair of objects in which the first component is $a$ and the second is $b$. In formal terms, the ordered pair can be defined set-theoretically as a set containing two elements:
 
-\\[
-(a, b) = \\{\\{a\\}, \\, \\{a, b\\}\\}
-\\]
+$$
+(a, b) = \{\{a\}, \, \{a, b\}\}
+$$
 
-The term \\(\\{a\\}\\) is the singleton, and \\(\\{a, b\\}\\) is the unordered pair. The element \\(a\\) appears in both, whereas \\(b\\) appears only in one. This definition is justified by the following result:
+The term $\{a\}$ is the singleton, and $\{a, b\}$ is the unordered pair. The element $a$ appears in both, whereas $b$ appears only in one. This definition is justified by the following result:
 
-\\[
+$$
 (a, b) = (c, d) \implies a = c \text{ and } b = d
-\\]
+$$
 
-To verify this property, suppose \\(\\{\\{a\\}, \\{a, b\\}\\} = \\{\\{c\\}, \\{c, d\\}\\}\\). We have two cases, depending on whether \\(a = b\\) or \\(a \neq b\\).
+To verify this property, suppose $\{\{a\}, \{a, b\}\} = \{\{c\}, \{c, d\}\}$. We have two cases, depending on whether $a = b$ or $a \neq b$.
 
-In the first case, when \\(a = b\\) we have \\(\\{a, b\\} = \\{a\\}\\), so the left-hand side becomes \\(\\{\\{a\\}\\}\\), a singleton set. For equality, the right-hand side must also be a singleton, which requires \\(\\{c\\} = \\{c, d\\}\\), implying \\(c = d\\). The single element on each side must coincide, so \\(\\{a\\} = \\{c\\}\\), and thus \\(a = c\\). Therefore, since \\(b = a = c = d\\), it follows that \\(a = c\\) and \\(b = d\\).
+In the first case, when $a = b$ we have $\{a, b\} = \{a\}$, so the left-hand side becomes $\{\{a\}\}$, a singleton set. For equality, the right-hand side must also be a singleton, which requires $\{c\} = \{c, d\}$, implying $c = d$. The single element on each side must coincide, so $\{a\} = \{c\}$, and thus $a = c$. Therefore, since $b = a = c = d$, it follows that $a = c$ and $b = d$.
 
-If \\(a \neq b\\), then the left-hand side contains two distinct elements: \\(\\{a\\}\\) and \\(\\{a, b\\}\\). The singleton \\(\\{a\\}\\) must correspond to either \\(\\{c\\}\\) or \\(\\{c, d\\}\\) on the right-hand side. If \\(\\{a\\} = \\{c, d\\}\\), then \\(c = d = a\\), which would make \\(\\{c\\} = \\{c, d\\}\\), resulting in a singleton on the right, contradicting the presence of two distinct elements on the left. Therefore, \\(\\{a\\} = \\{c\\}\\), so \\(a = c\\). It follows that \\(\\{a, b\\} = \\{c, d\\} = \\{a, d\\}\\), and since \\(a \neq b\\), it must be that \\(b = d\\).
+If $a \neq b$, then the left-hand side contains two distinct elements: $\{a\}$ and $\{a, b\}$. The singleton $\{a\}$ must correspond to either $\{c\}$ or $\{c, d\}$ on the right-hand side. If $\{a\} = \{c, d\}$, then $c = d = a$, which would make $\{c\} = \{c, d\}$, resulting in a singleton on the right, contradicting the presence of two distinct elements on the left. Therefore, $\{a\} = \{c\}$, so $a = c$. It follows that $\{a, b\} = \{c, d\} = \{a, d\}$, and since $a \neq b$, it must be that $b = d$.
 
-In both cases, \\(a = c\\) and \\(b = d\\), as required. The converse is straightforward, since if \\(a = c\\) and \\(b = d\\) then the two sets are identical by substitution.
+In both cases, $a = c$ and $b = d$, as required. The converse is straightforward, since if $a = c$ and $b = d$ then the two sets are identical by substitution.


### PR DESCRIPTION
## Summary

This PR fixes math rendering in the main Markdown entries by normalizing LaTeX delimiters and escaping.

## Changes

- Replaced double-escaped inline math delimiters like `\\(...\\)` with `$...$`.
- Replaced double-escaped display math delimiters like `\\[...\\]` with `$$...$$`.
- Restored normal LaTeX commands inside formulas.
- Converted formulas inside Markdown tables to inline math so they render correctly.

## Validation

- Extracted formulas from `Sets.md`, `Factorial.md`, and `Notable-products.md`.
- Verified that all extracted formulas parse successfully with KaTeX.
