### PR TITLE
Add a Spanish translation pilot

### DIFF
--- a/SPANISH_TRANSLATION.md
+++ b/SPANISH_TRANSLATION.md
@@ -1,0 +1,11 @@
+# Spanish translation
+
+This contribution provides a Spanish translation of the mathematical entries in Algebrica, using the terminology and conventions customary in Spain (`es-ES`). Translated entries live in an `ESP` directory beside their English source files and follow the existing language-directory convention in the repository.
+
+The English entries remain the source of truth. The translation preserves their Markdown structure, mathematical notation, equations, links, tables, diagrams, image references, source attribution, tags, and CC BY-NC 4.0 licence. It does not include generated PDF files or the separate book-building toolchain.
+
+The translation was prepared with AI assistance and reviewed with automated structural, mathematical, terminology, and residual-language checks. Source hashes are maintained outside this repository so that future reviews process only entries whose English source has changed. Upstream changes are checked weekly and translation updates are submitted explicitly rather than committed automatically.
+
+Original content: Antonio Lupetti and [Algebrica](https://algebrica.org/).
+
+Spanish adaptation: [73NKo](https://github.com/73nko/).

--- a/introduction/ESP/learning-mathematics.md
+++ b/introduction/ESP/learning-mathematics.md
@@ -1,0 +1,130 @@
+---
+title: Aprender matemáticas
+source: https://algebrica.org/learning-mathematics/
+license: CC BY-NC 4.0
+tags:
+  - introduction
+  - learning
+  - memory
+  - practice
+---
+
+## Una maleta llena de trapos
+
+En el verano de 1999 me matriculé en Ingeniería Informática en la Universidad de Roma La Sapienza. Había cursado los cinco años de secundaria en un modesto instituto de provincias especializado en estudios clásicos, y el choque con aquel mundo nuevo me dejó aturdido.
+
+Las matemáticas siempre habían sido una de mis asignaturas favoritas, no porque tuviera un talento especial para ellas, sino sencillamente porque me atraían más que el griego y el latín, más que la biología y la historia del arte. Aun así, saber que lo aprendido hasta entonces no alcanzaba el nivel exigido por una carrera que no era precisamente fácil me desanimaba.
+
+No tenía ni idea de que existieran las [sucesiones](../sequences/) y las [series numéricas](../series/).
+
+Nunca había resuelto una integral.
+
+Solo había oído hablar de ellas en mi último año de instituto, por boca del primo de un compañero que estudiaba Ingeniería Informática en la misma universidad en la que yo acabaría matriculándome, y su forma de describirlas hacía que parecieran cosas hostiles.
+
+Conocía los [números complejos](../complex-numbers/) solo de oídas, en esencia por la relación $i^2=-1$ y por el hecho de que una expresión de segundo grado con discriminante $\Delta \lt 0$ no admite soluciones reales.
+
+Pensaba que la geometría se reducía al estudio de los triángulos rectángulos y las figuras planas. No tenía ni idea de qué eran un [vector](../vectors/) o una [matriz](../matrices/), ni de cómo se resuelven [sistemas de ecuaciones lineales](../systems-of-linear-equations/) con varias incógnitas.
+
+Me di cuenta de que el equipaje que llevaba no se parecía en nada a una maleta, sino más bien a un pañuelo arrugado, atado de cualquier manera a un palo y del todo inadecuado para aquel viaje.
+
+Las clases empezaron en septiembre. Los primeros seis meses fueron brutales. Las lagunas de mi formación me impedían seguir las explicaciones. Me esforcé al máximo y los resultados fueron malos. En algún momento de abril, cerca del final del primer curso, comprendí que, si quería darme una oportunidad, tenía que volver a empezar desde el principio.
+
+No tenía ni idea de cómo ni por dónde empezar, y temía que no fuera nada fácil.
+
+## Aprender de memoria
+
+Por entonces vivía con mis padres en una pequeña casa de dos plantas, con jardín, varios gatos y un perro pastor de Maremma, a pocos kilómetros de Roma. Para llegar a la universidad tomaba cada día el tren de las seis y me desplazaba por la ciudad en transporte público. Las clases empezaban a las ocho. El trayecto era agotador, pero como me gustaba leer, me sumergía en los libros y el viaje se me hacía más corto de lo que era.
+
+No muy lejos de nuestra casa vivía un matrimonio: ella era médica; él, ingeniero y directivo de la mayor compañía petrolera italiana. Tenían la edad de mis padres, eran amigos de la familia desde hacía mucho tiempo y ambas parejas se veían con regularidad. Siempre que se presentaba la ocasión, él se interesaba por cómo me iba. Era un hombre amable, siempre sonriente, a diferencia de mí, que en aquella época tenía la moral por los suelos, saltaba por cualquier cosa y hasta sentía forzado el mero gesto de curvar los labios para esbozar una sonrisa. Sea como fuere, un día le hablé de mis dificultades y me escuchó durante toda la tarde.
+
+Las personas sabias no dan consejos, y él no me dio ninguno. Se limitó a decirme que, si quería entender las matemáticas, tendría que aprenderlas.
+Existe una diferencia sustancial entre _entender_ algo y _aprender_ a hacerlo. La distinción no es meramente semántica; atañe sobre todo a los procesos neurológicos implicados, que difieren en parte entre ambos casos. Entender es captar el significado de las cosas. Aprender es una habilidad compleja que se adquiere mediante la experiencia, la práctica, la repetición y la memoria. Es un mecanismo en el que intervienen la corteza motora, el cerebelo, los ganglios basales y los sistemas sensoriales, y está concebido para consolidar con el tiempo un conocimiento o una destreza determinados.
+
+En la base de todo ello se encuentra la memoria.
+
+En primaria, los niños _aprenden_ a contar; no _entienden_ cómo se hace. Con el tiempo se pasa de aprender a sumar números enteros a multiplicarlos entre sí. Que $2+2+2$ da $6$ se vuelve tan natural como aprender que la misma suma puede escribirse de forma compacta como $2 \times 3$. Nivel tras nivel se asimila que el producto $2 \times 2 \times 2$ es igual a $8$, que el mismo resultado puede escribirse de forma abreviada como $2^3$, que el exponente $3$ es el [logaritmo](../logarithms/) de $8$ en base $2$, o que la [raíz cuadrada](../radicals/) de $12$ también puede escribirse como $\sqrt{12} = \sqrt{3 \times 4} = 2 \times \sqrt{3}.$
+
+No hay forma de saberse las tablas de multiplicar que no sea aprenderlas de memoria, y eso significa repetirlas, repetirlas y volver a repetirlas hasta la extenuación.
+
+Un [estudio publicado en el _Times_](https://www.thetimes.com/uk/education/article/hardest-times-table-question-9x6-s3zdgd9k2) mostró que, de 317.000 alumnos de primaria, el 27% de los encuestados calculó mal el producto $9 \times 6$. No puedo aportar estadísticas que lo respalden, pero tengo la impresión de que, si se abordara al azar a treintañeros por la calle y se les preguntara sin rodeos cuánto dan $7 \times 8$ u $8 \times 9$, los resultados no serían mucho más alentadores. Intentemos, por ejemplo, resolver esta sencilla [integral indefinida](../indefinite-integrals/):
+
+$$\int \frac{1}{1+x^2} \ dx$$
+
+Si no se sabe que se trata de una integral cuya primitiva es $\arctan x + c,$ donde $c$ es una constante arbitraria, de nada sirve intentar obtener el resultado mediante sencillas manipulaciones. No es una integral que se resuelva con pasos rutinarios. En cambio, conocer de memoria la lista de las integrales más comunes permite reconocerla y resolverla al instante. O intentemos resolver este límite:
+
+$$\lim_{x\to 0}\frac{\sin x}{x}$$
+
+Usando únicamente la definición y sustituyendo $x=0$ en la expresión, se obtiene una [forma indeterminada](../indeterminate-forms/) que no dice nada acerca de cómo se comporta la expresión cuando el [límite](../limits/) se aproxima a $0.$ El que acabamos de plantear es un [límite notable](../remarkable-limits/) y su resultado es $1$. La demostración no es especialmente complicada, pero, cuando hay que resolver un ejercicio, resulta mucho más útil, si no necesario, recordar que este límite es exactamente $1,$ en lugar de perderse cada vez en cálculos inútiles.
+
+Esta observación sobre el papel de la memoria puede parecer trivial, pero en realidad no lo es en absoluto. Para aprender matemáticas es indispensable memorizar una gran cantidad de información, reglas, simplificaciones y trucos para resolver problemas. No hay otra manera. La teoría es útil, pero en su justa medida.
+
+Es como aprender un idioma.
+
+Si te concentras demasiado en la gramática, nunca llegarás a hablarlo con fluidez.
+
+## No es cuestión de talento
+
+En mi primer curso de primaria, la maestra sugirió a mis padres que me matricularan en una escuela de música. Recuerdo que en clase hacíamos sencillos ejercicios rítmicos con instrumentos de percusión, y se me daban con cierta facilidad. Había aprendido a sacar en una melódica la melodía de _Hymne_, de Vangelis, una pieza que por aquellos años había alcanzado una enorme popularidad en Italia, en parte gracias al anuncio televisivo de una conocida marca de pasta. No me limitaba a acertar las notas: le daba un toque de personalidad al prolongar las ligaduras más largas y los silencios, como un músico verdaderamente curtido.
+
+Unas semanas después empecé a recibir clases particulares de piano y descubrí que, además de entusiasmarme, se me daba con mucha naturalidad. A los ocho años tocaba a Bach y Mozart mejor que muchos niños de mi edad. Me bastaba con escuchar un par de veces una pieza en la radio para reproducirla de oído en el teclado. Durante mis años de instituto tuve un teclado Korg conectado a la tarjeta de sonido del ordenador, con el que componía, arreglaba y producía mis propias canciones.
+El tiempo es la base de la música, que se cuantifica en negras, corcheas, semicorcheas, tresillos, etcétera. Las fracciones y la música van de la mano, y se me daban francamente bien las dos.
+
+Hacia los trece años, un conocido de mi padre me oyó tocar y vio talento en mí. Así que propuso que hiciera una audición informal con un profesor del conservatorio de Roma. La idea de medirme con profesionales de una institución tan prestigiosa me llenaba de orgullo y entusiasmo, y pasé un fin de semana entero practicando al piano.
+
+El encuentro tuvo lugar unos días después, en una pequeña sala desnuda de Santa Cecilia que daba al claustro del convento de las Ursulinas. El profesor me hizo tocar una pieza y escuchó hasta el final sin interrumpirme. Después, con toda la amabilidad de la que fue capaz, me dijo: tocar no consiste en golpear las teclas con los dedos. Significa poner intención, leer la partitura y saber interpretarla como habría querido el compositor, valorar el uso de los pedales y muchísimas cosas más. El corazón no basta; la técnica es imprescindible.
+
+Y yo no la tenía.
+
+Volví a casa decepcionado y enfadado, porque me parecía haber malgastado años limitándome a salir del paso en algo que, a la hora de la verdad, no dominaba ni de lejos tan bien como había imaginado. Así que decidí esforzarme al máximo para mejorar. Cambié de escuela de música y me volqué en un material tan aburrido como extenuante, compuesto por ejercicios mecánicos para las articulaciones, escalas y acordes destinados a entrenar la movilidad de los dedos y la memoria muscular del antebrazo. Mi repertorio viró bruscamente hacia Hanon, Clementi y Pozzoli. Quien haya pasado por ello sabrá lo que significa.
+
+Quería dominar la técnica y pronto comprendí que tendría que practicar hasta caer rendido. Al cabo de pocas semanas advertí que había progresado de forma increíble: mi manera de interpretar a los compositores clásicos había mejorado perceptiblemente, y un dominio más sólido de la técnica me permitía concentrarme más en la expresión y dar a las piezas una profundidad musical que hasta entonces no sabía que podía alcanzar.
+
+Lo mismo vale para las matemáticas y, en general, según se dice, para todos los ámbitos de la vida. Cada cual puede tener sus propias inclinaciones y preferencias, pero estoy convencido de que se pueden lograr resultados dignos de respeto incluso en las disciplinas que menos nos gustan, si estamos dispuestos a afrontarlas con el esfuerzo y la constancia que exigen.
+
+## Practicar, practicar y practicar
+
+Ser capaz de resolver un sistema lineal mediante la [regla de Cramer](../cramers-rule/) o una [integral por sustitución](../integration-by-substitution/) no es una mera cuestión de intuición matemática. O, mejor dicho, la intuición es útil, pero no es un don innato reservado a unos pocos. Puede adquirirse y desarrollarse con la práctica. Veamos un ejemplo muy sencillo:
+
+$$\log_a(x \cdot \cos x )$$
+
+Si no se conoce la propiedad del logaritmo de un producto, resulta difícil adivinar que la expresión puede reescribirse de la forma equivalente:
+
+$$\log_a(x \cdot \cos x)=\log_a x+\log_a(\cos x)$$
+
+Primero hay que asimilarla y memorizarla. Solo entonces puede la intuición establecer las conexiones necesarias y sugerirnos que, para trabajar con una expresión dada, podemos recurrir a una de las dos formulaciones equivalentes. Cuál de ellas conviene utilizar depende del contexto, y cuanto más se practica, mayor es la capacidad de escoger automáticamente la adecuada.
+
+Veamos otro ejemplo, con un integrando que contiene la expresión siguiente:
+
+$$\sqrt{a^2 - x^2}$$
+
+Las integrales de este tipo suelen resolverse por sustitución, y la más inmediata consiste en tomar $x=a \sin t$ y, al derivar respecto de $t$, obtener $dx = a \cos t \ dt.$ Esta elección se debe a la [identidad pitagórica](../pythagorean-identity/) $\sin^{2}x + \cos^{2}x = 1$, que en este caso permite simplificar la expresión situada bajo la raíz. También aquí la intuición sirve de poco si antes no se la ha entrenado, mediante la práctica, para reconocer esta clase de patrones recurrentes en las integrales.
+
+Contrariamente a lo que suele creerse, la mayoría de los problemas matemáticos que se afrontan desde la secundaria hasta los primeros años de universidad implican poco más que procedimientos mecánicos. Pero, como sucede al aprender a tocar el piano, hace falta mucha práctica para aplicar esos procedimientos con soltura y adquirir la confianza necesaria.
+
+En cualquier caso, al terminar el primer curso solo había conseguido aprobar dos de los cinco exámenes del plan de estudios. No me desanimé y decidí dedicar los tres meses de verano a volver a empezar literalmente desde cero. Rescaté mis antiguos libros de texto, hice acopio de fotocopias sobre los temas nuevos y recomencé por lo más básico: [potencias](../powers/), radicales, [exponenciales](../exponential-function/), logaritmos, trigonometría, [ecuaciones](../equations/), [inecuaciones](../inequalities/), sistemas, números complejos, series, sucesiones, [derivadas](../derivatives/), integrales.
+
+Empezaba a primera hora de la mañana y terminaba bien entrada la tarde. Copiaba obsesivamente en papel las fórmulas y las propiedades de los principales objetos matemáticos, y llenaba páginas de ejercicios hasta obtener los resultados correctos. Tras las primeras semanas me sentía más seguro y desenvuelto. Cuanto más aprendía, más ganas tenía de afrontar problemas cada vez más complejos, y pronto mis sesiones se prolongaron varias horas después de cenar.
+
+Cuando llegó septiembre y volvieron a empezar las clases, estaba a otro nivel. Recuperé los exámenes pendientes y seguí adelante, repitiendo el mismo método de memoria y práctica que había adoptado durante el verano. En el examen de investigación operativa obtuve 28 puntos de 30. El 11 de enero nos presentamos cuatro personas al examen de matemática discreta para ordenadores electrónicos. Había pasado todo diciembre estudiando. Saqué un 25, la nota más alta de todos.
+
+Que conste: no hice nada excepcional.
+
+Pero había comprendido que, si seguía así, llegaría al final de un viaje que, apenas unos meses antes, me había parecido imposible completar.
+
+## No es solo cuestión de método
+
+Todos hemos encontrado al menos una vez en la vida un método de estudio que funciona. No existe una receta universal válida para todo el mundo, así que desconfía de quien prometa lo contrario. Cada persona aprende mediante una combinación de experiencia y procesos asociativos que depende en gran medida de cómo organiza y consolida la información su cerebro. Sin embargo, hay algo que no admite duda: no se puede aprender sin entrenar.
+
+Los grandes modelos de lenguaje modernos, como ChatGPT, Claude y Gemini, se entrenan con miles de millones de parámetros antes de ser capaces de identificar las correlaciones necesarias para generar una respuesta coherente con los datos que reciben. Este tipo de entrenamiento, por lo general muy costoso tanto en tiempo como en recursos, comprende numerosos ciclos durante los cuales, dicho de forma muy sencilla, estos sistemas aprenden gradualmente a reducir el error estadístico y a producir resultados cada vez más precisos. Las correlaciones aprendidas durante este proceso forman una especie de memoria distribuida que se emplea para procesar nuevos datos con una precisión creciente.
+
+Memoria, repetición, entrenamiento, reducción del error.
+
+La forma en que «aprenden» los grandes modelos de lenguaje es, en ciertos aspectos, análoga a la forma en que se «aprenden» las matemáticas, al menos en el sentido descrito hasta aquí. No afirmo que sea un modelo universal, pero creo que se le aproxima, por lo menos en sus principios fundamentales. Al fin y al cabo, nadie se dejaría operar por un cirujano que solo hubiera estudiado en libros, sin haberse entrenado también en un quirófano.
+
+Lo que quiero decir es que las dificultades que muchas personas encuentran al estudiar matemáticas no proceden necesariamente de la dificultad intrínseca de la materia —aunque esta sin duda influye—, sino sobre todo de no ser conscientes del papel fundamental que desempeñan la memoria y la práctica en el proceso de comprensión y aprendizaje.
+
+Cuando empecé a escribir las primeras entradas de Algebrica, en mayo de 2023, intenté estructurar el contenido para que fuera fácil de consultar, de esquematizar y de memorizar, eliminando lo superfluo y conservando lo que juzgaba verdaderamente necesario. Espero que este enfoque ayude a las muchas personas que utilizan el sitio con regularidad a entender mejor las matemáticas y a superar las barreras que a menudo hacen que parezcan más difíciles, lejanas e inaccesibles de lo que en realidad son.
+
+
+> Nota del autor: este texto se tradujo del italiano y puede contener algunos matices lingüísticos que no reflejen por completo la versión original, ya que el inglés no es mi lengua materna. Por favor, no seáis demasiado severos.
+> Derechos de autor © Antonio Lupetti. Este material no puede reproducirse sin autorización previa.

--- a/logic/ESP/propositional-logic.md
+++ b/logic/ESP/propositional-logic.md
@@ -1,0 +1,289 @@
+---
+title: Lógica proposicional
+source: https://algebrica.org/propositional-logic/
+license: CC BY-NC 4.0
+tags:
+  - atomic-proposition
+  - conjunctive-normal-form
+  - contradiction
+  - deductive-closure
+  - disjunctive-normal-form
+  - inference-rules
+  - interpretation
+  - logical-connective
+  - logical-consequence
+  - logical-equivalence
+  - modus-ponens
+  - modus-tollens
+  - propositional-constants
+  - propositional-logic
+  - satisfiability
+  - semantics
+  - tautology
+  - truth-table
+  - valuation
+  - well-formed-formula
+---
+
+## Lenguaje proposicional
+
+La lógica proposicional estudia los argumentos cuya validez depende del modo en que las conectivas proposicionales combinan proposiciones. Considera cada proposición atómica verdadera o falsa y determina el valor de verdad de una proposición compuesta a partir de los valores de verdad de sus componentes.
+
+El contenido de una proposición atómica es irrelevante para este cálculo. Si un argumento tiene la forma $p,$ $p \rightarrow q,$ por tanto $q,$ su validez depende de esa forma, con independencia de las proposiciones representadas por $p$ y $q.$ Esta restricción confiere precisión a la lógica proposicional, pero también limita lo que el lenguaje puede expresar.
+
+Un lenguaje proposicional $\mathrm{Prop}[P]$ tiene símbolos atómicos, conectivas lógicas y paréntesis. El conjunto $P$ contiene los símbolos de proposición atómica; por ejemplo, $P = \{p, q, r\}.$ Los paréntesis indican cómo agrupan las conectivas las fórmulas.
+
+El lenguaje empleado aquí tiene las conectivas siguientes:
+
++ Negación $\neg$
++ Conjunción $\wedge$
++ Disyunción $\lor$
++ Condicional material $\rightarrow$
++ Bicondicional material $\leftrightarrow$
++ Disyunción exclusiva $\oplus$
+
+La elección de las conectivas primitivas es convencional. El bicondicional y la disyunción exclusiva pueden definirse a partir de otras conectivas, pero el uso de símbolos propios abrevia las fórmulas habituales.
+
+El lenguaje también tiene dos constantes proposicionales, $\top$ y $\bot.$ La primera es verdadera bajo toda interpretación y la segunda es falsa bajo toda interpretación. No toman argumentos, por lo que son conectivas de aridad cero, y cada una tiene el valor de verdad de una fórmula compuesta: $\top$ tiene el de $p \lor \neg p$ y $\bot$ el de $p \wedge \neg p.$
+
+Una fórmula construida con los símbolos de $P$ de acuerdo con las reglas de formación es una fórmula bien formada (FBF). Las proposiciones atómicas son las FBF más sencillas, mientras que cualquier otra FBF tiene una o más FBF como componentes inmediatos.
+
+## Conectivas lógicas
+
+Una conectiva es veritativo-funcional cuando los valores de verdad de sus componentes inmediatos determinan de manera unívoca el valor de verdad de la fórmula compuesta. Todas las conectivas de $\mathrm{Prop}[P]$ son veritativo-funcionales.
+
++ La negación $\neg p$ es verdadera precisamente cuando $p$ es falsa.
++ La conjunción $p \wedge q$ es verdadera precisamente cuando $p$ y $q$ son ambas verdaderas.
++ La disyunción $p \lor q$ es verdadera precisamente cuando al menos una de $p$ y $q$ es verdadera. La conectiva $\lor$ tiene sentido inclusivo, por lo que $p \lor q$ también es verdadera cuando ambos disyuntos son verdaderos.
++ El condicional material $p \rightarrow q$ es falso precisamente cuando su antecedente $p$ es verdadero y su consecuente $q$ es falso.
++ El bicondicional material $p \leftrightarrow q$ es verdadero precisamente cuando $p$ y $q$ tienen el mismo valor de verdad.
++ La disyunción exclusiva $p \oplus q$ es verdadera precisamente cuando $p$ y $q$ tienen valores de verdad distintos.
+
+El sentido de un condicional requiere atención. La proposición «$p$ solo si $q$» es $p \rightarrow q,$ mientras que «$p$ si $q$» es $q \rightarrow p.$ En la primera fórmula, $p$ es una condición suficiente para $q,$ y $q$ es una condición necesaria para $p.$
+
+El lenguaje ordinario contiene conectivas que no son veritativo-funcionales. La verdad de «es necesario que $p$» no viene determinada únicamente por la verdad de $p$. Palabras como «pero» y «aunque» pueden expresar un contraste que la conjunción no conserva, mientras que un condicional contrafáctico no es, en general, veritativo-funcional. Una simbolización en lógica proposicional solo conserva la estructura veritativo-funcional de la proposición original.
+
+## Ejemplo de simbolización
+
+Consideremos un lenguaje proposicional $\mathrm{Prop}[P]$ sobre $P = \{p, q\},$ con la siguiente clave de simbolización:
+
++ $p =$ la puerta está abierta.
++ $q =$ la ventana está abierta.
+
+Las dos proposiciones atómicas y las conectivas bastan para simbolizar varias proposiciones compuestas.
+
++ La puerta no está abierta se escribe $\neg p.$
++ La puerta y la ventana están abiertas se escribe $p \wedge q.$
++ La puerta o la ventana están abiertas, quizá ambas, se escribe $p \lor q.$
++ Si la puerta está abierta, entonces la ventana está abierta se escribe $p \rightarrow q.$
++ La puerta está abierta si y solo si la ventana está abierta se escribe $p \leftrightarrow q.$
++ O bien la puerta o bien la ventana está abierta, pero no ambas, se escribe $p \oplus q.$
++ Ni la puerta ni la ventana están abiertas se escribe $\neg(p \lor q).$
++ La negación del condicional «si la puerta está abierta, entonces la ventana está abierta» se escribe $\neg(p \rightarrow q).$
+
+Los paréntesis son necesarios en las dos últimas fórmulas porque el alcance de la negación es la fórmula compuesta completa. Por tanto, $\neg(p \lor q)$ difiere de $\neg p \lor q.$
+
+## Reglas de formación
+
+Las reglas de formación constituyen una definición inductiva de las FBF de $\mathrm{Prop}[P].$
+
++ Toda proposición atómica $p \in P$ es una FBF, y las constantes $\top$ y $\bot$ son FBF.
++ Si $\varphi$ es una FBF, entonces $\neg\varphi$ es una FBF.
++ Si $\varphi$ y $\psi$ son FBF, entonces son FBF $(\varphi \wedge \psi),$ $(\varphi \lor \psi),$ $(\varphi \rightarrow \psi),$ $(\varphi \leftrightarrow \psi),$ así como $(\varphi \oplus \psi)$.
++ Ninguna otra expresión es una FBF.
+
+La última cláusula excluye toda cadena que no pueda obtenerse mediante un número finito de aplicaciones de las cláusulas anteriores. Estas cláusulas también determinan la estructura de cada fórmula. Toda FBF compuesta tiene una única conectiva principal, que es la conectiva aplicada en el último paso de su construcción.
+
+Omitimos el par de paréntesis exterior cuando no se produce ninguna ambigüedad. Conforme a esta convención, la conectiva principal de $\neg(p \wedge q)$ es $\neg,$ mientras que la conectiva principal de $\neg p \wedge q$ es $\wedge.$ El alcance de una aparición de una conectiva es la subfórmula a la que se aplica esa aparición. Por tanto, los paréntesis determinan tanto la conectiva principal como el alcance de las conectivas interiores.
+
+Otras dos convenciones permiten eliminar los paréntesis restantes. Las conectivas tienen un orden de precedencia, desde la que liga con mayor fuerza hasta la que liga con menor fuerza:
+
+$$
+\neg \quad \wedge \quad \lor \quad \rightarrow \quad \leftrightarrow
+$$
+
+Por tanto, la fórmula $\neg p \wedge q \rightarrow r$ es una abreviación de $((\neg p) \wedge q) \rightarrow r.$ Las conectivas con la misma precedencia se asocian por la izquierda, de modo que $p \wedge q \wedge r$ abrevia $(p \wedge q) \wedge r.$ La agrupación es irrelevante para $\wedge$ y $\lor,$ que son asociativas, pero no lo es para $\rightarrow.$ Bajo $M(p) = M(q) = M(r) = F$ la fórmula $(p \rightarrow q) \rightarrow r$ es falsa, mientras que $p \rightarrow (q \rightarrow r)$ es verdadera.
+
+> Algunos textos interpretan por la derecha una cadena de condicionales, de modo que $p \rightarrow q \rightarrow r$ abrevia $p \rightarrow (q \rightarrow r).$ Las dos convenciones discrepan; los paréntesis explícitos en los condicionales anidados evitan la ambigüedad.
+
+## Semántica
+
+La semántica de la lógica proposicional tiene dos valores de verdad:
+
+$$
+\mathrm{Bool} := \{\ T, F\ \}
+$$
+
+Las constantes reciben siempre el mismo valor: $T$ para $\top$ y $F$ para $\bot.$ Las tablas de verdad características definen las conectivas. La tabla conjunta de las seis conectivas es la siguiente:
+
+$$
+\begin{array}{cc|cccccc}
+p & q & \neg p & p \wedge q & p \lor q & p \rightarrow q & p \leftrightarrow q & p \oplus q \\[6pt]
+\hline
+T & T & F & T & T & T & T & F \\[6pt]
+T & F & F & F & T & F & F & T \\[6pt]
+F & T & T & F & T & T & F & T \\[6pt]
+F & F & T & F & F & T & T & F
+\end{array}
+$$
+
+Una tabla de verdad completa tiene una fila por cada asignación de valores de verdad a las distintas proposiciones atómicas de una fórmula. Si una fórmula contiene $n$ proposiciones atómicas distintas, su tabla de verdad completa tiene $2^n$ filas. La columna situada bajo la conectiva principal contiene el valor de verdad de la fórmula completa para cada asignación.
+
+La tabla también proporciona las equivalencias lógicas siguientes:
+
++ $p \rightarrow q \equiv \neg p \lor q$
++ $p \leftrightarrow q \equiv (p \rightarrow q) \wedge (q \rightarrow p)$
++ $p \oplus q \equiv (p \lor q) \wedge \neg(p \wedge q)$
+
+El símbolo $\equiv$ es una relación del metalenguaje entre fórmulas. Significa que las fórmulas tienen el mismo valor de verdad bajo toda asignación. El símbolo no es otra conectiva de $\mathrm{Prop}[P].$
+
+## Interpretaciones
+
+Una interpretación, también denominada valoración en lógica proposicional, es una función que asigna un valor de verdad a cada proposición atómica de $P$:
+
+$$
+M : P \rightarrow \{T, F\}
+$$
+
+El valor de una fórmula compuesta bajo $M$ queda entonces determinado recursivamente por su formación y por las tablas de verdad de las conectivas.
+
++ Si $\varphi$ es verdadera bajo $M,$ escribimos $M \models \varphi$ y decimos que $M$ es un modelo de $\varphi.$
++ Si $\varphi$ es falsa bajo $M,$ escribimos $M \not\models \varphi$ y decimos que $M$ es un contramodelo de $\varphi.$
+
+Consideremos la interpretación en la que $p$ es verdadera y $q$ es falsa. A la fórmula $p \rightarrow \neg q$ le corresponde la fila siguiente:
+
+$$
+\begin{array}{cc|cc}
+p & q & \neg q & p \rightarrow \neg q \\[6pt]
+\hline
+T & F & T & T
+\end{array}
+$$
+
+Bajo esta interpretación, el antecedente $p$ y el consecuente $\neg q$ son verdaderos. En consecuencia, $p \rightarrow \neg q$ es verdadera, y $M \models p \rightarrow \neg q.$
+
+Las nociones siguientes se definen cuantificando sobre las interpretaciones.
+
++ Una fórmula $\varphi$ es satisfacible si alguna interpretación la satisface.
++ Una fórmula $\varphi$ es una tautología si toda interpretación la satisface.
++ Una fórmula $\varphi$ es una contradicción si ninguna interpretación la satisface.
++ Una fórmula $\varphi$ es contingente si alguna interpretación la satisface y alguna interpretación no la satisface.
+
+Por tanto, toda tautología y toda fórmula contingente es satisfacible, mientras que toda contradicción es insatisfacible. Un conjunto de fórmulas $S$ es conjuntamente satisfacible si alguna interpretación satisface todas las fórmulas de $S.$ Si no existe tal interpretación, $S$ es conjuntamente insatisfacible, o inconsistente.
+
+Dos fórmulas $\varphi$ y $\psi$ son lógicamente equivalentes cuando coinciden bajo toda interpretación:
+
+$$
+\varphi \equiv \psi \Longleftrightarrow \forall M \ (M \models \varphi \Longleftrightarrow M \models \psi)
+$$
+
+## Consecuencia lógica
+
+Una fórmula $\varphi$ es consecuencia lógica de un conjunto de fórmulas $S$ si toda interpretación que satisface todas las fórmulas de $S$ también satisface $\varphi.$ Esta relación se escribe del modo siguiente:
+
+$$
+S \models \varphi
+$$
+
+De forma equivalente, ninguna interpretación hace verdaderas todas las fórmulas de $S$ y mantiene $\varphi$ falsa. El símbolo $\models$ es una relación del metalenguaje, mientras que $\rightarrow$ es una conectiva que forma una nueva fórmula. Para dos fórmulas $\varphi$ y $\psi,$ la relación entre ambas es la siguiente:
+
+$$
+\varphi \models \psi \Longleftrightarrow \models \varphi \rightarrow \psi
+$$
+
+Consideremos el conjunto $S = \{p, p \rightarrow q\}$ y la consecuencia propuesta $q.$ La tabla de verdad pertinente es la siguiente:
+
+$$
+\begin{array}{cc|c}
+p & q & p \rightarrow q \\[6pt]
+\hline
+T & T & T \\[6pt]
+T & F & F \\[6pt]
+F & T & T \\[6pt]
+F & F & T
+\end{array}
+$$
+
+Solo la primera fila hace verdaderos ambos miembros de $S$ y esa fila también hace verdadera $q$. Por tanto, $S \models q.$ La regla de inferencia correspondiente es el modus ponens.
+
+Una tercera formulación de la relación sustituye el examen de los modelos de $S$ por una cuestión acerca de un único conjunto de fórmulas:
+
+$$
+S \models \varphi \Longleftrightarrow S \cup \{\neg\varphi\} \ \text{es insatisfacible}
+$$
+
+Supongamos que $S \models \varphi$ y sea $M$ una interpretación que satisface todas las fórmulas de $S \cup \{\neg\varphi\}.$ De $M \models S$ obtenemos $M \models \varphi,$ mientras que $M \models \neg\varphi$ da $M \not\models \varphi,$ y las dos conclusiones son incompatibles. Recíprocamente, supongamos que $S \cup \{\neg\varphi\}$ es insatisfacible y sea $M \models S.$ Si $\varphi$ fuese falsa bajo $M,$ entonces $M$ satisfaría $\neg\varphi$ y, por tanto, el conjunto completo. En consecuencia, todo modelo de $S$ es un modelo de $\varphi.$ Los [procedimientos de deducción automatizada](../automated-deduction-in-propositional-logic/) comprueban el miembro derecho, pues es posible buscar mecánicamente una demostración de insatisfacibilidad.
+
+## Reglas de inferencia
+
+Una regla de inferencia es un esquema para obtener una conclusión a partir de una o más premisas. Si $S \vdash \varphi,$ entonces $\varphi$ tiene una derivación a partir de premisas de $S$ dentro del sistema de demostración elegido. El símbolo $\vdash$ se refiere a las derivaciones, mientras que $\models$ se refiere a las interpretaciones.
+
+Un sistema de demostración es correcto cuando $S \vdash \varphi$ implica $S \models \varphi,$ y es completo cuando $S \models \varphi$ implica $S \vdash \varphi.$ Los sistemas de demostración habituales para la lógica proposicional tienen ambas propiedades. La clausura deductiva de $S$ es el conjunto de sus consecuencias lógicas:
+
+$$
+\mathrm{Cn}(S) := \{\ \varphi \mid S \models \varphi \ \}
+$$
+
+En un sistema correcto y completo, $\mathrm{Cn}(S)$ es también el conjunto de fórmulas derivables de $S.$ Es infinito para todo $S,$ pues contiene todas las tautologías del lenguaje.
+
+El modus ponens permite obtener $q$ a partir de $p$ y $p \rightarrow q$:
+
+$$
+\frac{p \qquad p \rightarrow q}{q}
+$$
+
+El modus tollens permite obtener $\neg p$ a partir de $\neg q$ y $p \rightarrow q$:
+
+$$
+\frac{\neg q \qquad p \rightarrow q}{\neg p}
+$$
+
+El silogismo hipotético permite obtener $p \rightarrow r$ a partir de $p \rightarrow q$ y $q \rightarrow r$:
+
+$$
+\frac{p \rightarrow q \qquad q \rightarrow r}{p \rightarrow r}
+$$
+
+En cada esquema, las fórmulas situadas sobre la línea son las premisas y la fórmula situada bajo la línea es la conclusión.
+
+Por ejemplo, sea $p$ la afirmación de que llueve, sea $q$ la afirmación de que el suelo está mojado y sea $r$ la afirmación de que el partido se ha cancelado. A partir de $p \rightarrow q$ y $q \rightarrow r,$ el silogismo hipotético da $p \rightarrow r.$ Si $p$ es también una premisa, el modus ponens da $r.$
+
+Otras reglas rigen las conectivas restantes. La eliminación y la introducción de la conjunción relacionan una conjunción con sus miembros, la introducción de la disyunción debilita una fórmula convirtiéndola en una disyunción y el silogismo disyuntivo elimina un disyunto:
+
+$$
+\frac{\varphi \wedge \psi}{\varphi} \qquad \frac{\varphi \qquad \psi}{\varphi \wedge \psi} \qquad \frac{\varphi}{\varphi \lor \psi} \qquad \frac{\varphi \lor \psi \qquad \neg\varphi}{\psi}
+$$
+
+Una sola regla, la [resolución](../automated-deduction-in-propositional-logic/), engloba a la vez el modus ponens, el modus tollens y el silogismo disyuntivo, y es la regla sobre la que se construye la búsqueda mecánica de demostraciones.
+
+## Formas normales
+
+Un literal es una proposición atómica o la negación de una proposición atómica. Una cláusula es una disyunción de literales y un término es una conjunción de literales.
+
+Una fórmula está en forma normal conjuntiva (FNC) si es una conjunción de cláusulas:
+
+$$
+(l_{1,1} \lor \cdots \lor l_{1,k}) \wedge (l_{2,1} \lor \cdots \lor l_{2,m}) \wedge \cdots
+$$
+
+Una fórmula está en forma normal disyuntiva (FND) si es una disyunción de términos:
+
+$$
+(l_{1,1} \wedge \cdots \wedge l_{1,k}) \lor (l_{2,1} \wedge \cdots \wedge l_{2,m}) \lor \cdots
+$$
+
+En cualquiera de las dos formas normales solo aparecen las conectivas $\neg,$ $\wedge,$ así como $\lor$ y toda negación tiene como alcance una proposición atómica. Un solo literal es a la vez una cláusula y un término, por lo que es tanto una fórmula en FNC como una fórmula en FND.
+
+Toda fórmula proposicional es lógicamente equivalente a una fórmula en FNC y a una fórmula en FND. Un método de conversión elimina primero $\rightarrow,$ $\leftrightarrow,$ así como $\oplus,$ desplaza después cada negación hacia el interior mediante la doble negación y las leyes de De Morgan y, por último, aplica las leyes distributivas.
+
+Por ejemplo, consideremos $\neg(p \lor q) \rightarrow r.$ La equivalencia $\varphi \rightarrow \psi \equiv \neg\varphi \lor \psi$ proporciona el cálculo siguiente:
+
+$$
+\neg(p \lor q) \rightarrow r \equiv \neg\neg(p \lor q) \lor r \equiv (p \lor q) \lor r
+$$
+
+La fórmula resultante es equivalente a $p \lor q \lor r.$ Es una única cláusula y, por tanto, está en FNC. Como cada disyunto es también un término de un solo literal, la misma fórmula está en FND.
+
+Una tabla de verdad completa ofrece otra demostración de los teoremas sobre las formas normales. Para la FND, se toma cada fila en la que la fórmula original es verdadera, se forma un término que solo es verdadero en esa fila y se establece la disyunción de esos términos. Para la FNC, se toma cada fila en la que la fórmula es falsa, se forma una cláusula que solo es falsa en esa fila y se establece la conjunción de esas cláusulas. Cuando la fórmula es una contradicción, $p \wedge \neg p$ es una forma normal equivalente. Cuando es una tautología, $p \lor \neg p$ es una forma normal equivalente.
+
+El procedimiento DPLL y varios métodos relacionados de satisfacibilidad toman como entrada fórmulas en FNC, al igual que el [procedimiento de resolución](../automated-deduction-in-propositional-logic/).

--- a/sets-and-numbers/ESP/sets.md
+++ b/sets-and-numbers/ESP/sets.md
@@ -1,0 +1,489 @@
+---
+title: Conjuntos
+source: https://algebrica.org/sets/
+license: CC BY-NC 4.0
+tags:
+  - bijection
+  - cardinality
+  - cartesian-product
+  - de-morgan-laws
+  - disjoint-union
+  - inclusion-exclusion
+  - indexed-family
+  - indexed-product
+  - ordered-pair
+  - partition
+  - power-set
+  - set
+  - set-operations
+  - subset
+  - universal-set
+---
+
+## Introducción
+
+Un conjunto es una colección de objetos llamados elementos y queda determinado por completo por los objetos que pertenecen a él. Dos conjuntos son iguales precisamente cuando tienen los mismos elementos. Ni el orden en que se enumeran los elementos ni las repeticiones en la lista modifican el conjunto. Por ejemplo, las tres descripciones siguientes definen el mismo conjunto:
+
+$$
+\{1,2,3\}=\{3,1,2\}=\{1,1,2,3,3\}
+$$
+
+Un conjunto con exactamente un elemento es un conjunto unitario. Por tanto, $\{a\}$ es un conjunto unitario, mientras que $\{a,b\}$ tiene dos elementos cuando $a\neq b.$ Los conjuntos suelen representarse mediante letras mayúsculas $A,$ $B,$ $C,$ y sus elementos, mediante letras minúsculas. La notación $x\in A$ indica que $x$ pertenece a $A,$ mientras que $x\notin A$ indica que $x$ no pertenece a $A.$ La pertenencia debe tener un valor de verdad inequívoco para cada objeto considerado.
+
+Un conjunto puede describirse por enumeración o mediante notación por comprensión. La enumeración consiste en indicar explícitamente cada elemento del conjunto y resulta práctica cuando la cardinalidad del conjunto es finita y pequeña:
+
+$$
+A = \{a_1, a_2, a_3, a_4\}
+$$
+
+Cuando los elementos son numerosos o infinitos, la notación por comprensión suele ser más breve. Esta selecciona, dentro de un conjunto especificado previamente, los elementos que satisfacen una condición dada. Por ejemplo, definimos un subconjunto de los [números enteros](../integers/) escribiendo:
+
+$$
+A = \{\ x \in \mathbb{Z} \mid x > 4, \ x \leq 8 \ \}
+$$
+
+El conjunto ambiente $\mathbb{Z}$ limita los candidatos a pertenecer al conjunto. A continuación, las dos inecuaciones seleccionan los cuatro enteros siguientes:
+
+$$
+A = \{5, 6, 7, 8\}
+$$
+
+> En la teoría ingenua de conjuntos, una condición arbitraria no define necesariamente un conjunto. Una expresión de la forma $\{\ x\in S\mid P(x)\ \}$ extrae elementos de un conjunto $S$ ya disponible. Sin un conjunto ambiente de este tipo, una condición puede describir una colección que no puede ser un conjunto. La paradoja de Russell surge de una definición no restringida de esta clase.
+
+El conjunto vacío no contiene elementos, se denota por $\emptyset$ o $\{\ \},$ y desempeña en la teoría de conjuntos un papel análogo al del cero en la aritmética.
+
+## El conjunto universal
+
+Se denomina conjunto universal a una colección que contiene todos los objetos considerados, y se representa por $U.$ Todos los conjuntos de un contexto dado son subconjuntos de $U.$ La elección de $U$ depende de la situación. En teoría elemental de números se suele trabajar con $U = \mathbb{Z},$ mientras que en análisis real la elección habitual es $U = \mathbb{R}.$
+
+> El conjunto universal es la herramienta que permite definir sin ambigüedad la noción de complementario de un conjunto, como se explica en la sección sobre operaciones con conjuntos.
+
+## Cardinalidad de los conjuntos finitos
+
+La cardinalidad de un conjunto finito $A,$ denotada por $|A|,$ es el número de elementos de $A.$ Las cardinalidades también pueden compararse mediante [funciones](../functions/). Dos conjuntos $A$ y $B$ tienen la misma cardinalidad cuando existe una [biyección](../injective-surjective-and-bijective-functions/) de $A$ en $B$. Esta condición se escribe del modo siguiente:
+
+$$
+|A|=|B| \iff \text{existe una biyección } f\colon A\to B
+$$
+
+Para conjuntos finitos, esta condición equivale a la igualdad entre sus números de elementos. El conjunto vacío tiene cardinalidad $|\emptyset|=0.$
+
+Para conjuntos infinitos, las biyecciones definen la igualdad de cardinalidades incluso cuando ninguno de los conjuntos tiene un número finito de elementos. [Cardinalidad y conjuntos numerables](../cardinality-and-countable-sets/) amplía esta definición a los conjuntos infinitos e incluye la comparación con los conjuntos potencia.
+
+La cardinalidad del producto cartesiano de dos conjuntos finitos $A$ y $B$ viene dada por:
+
+$$
+|A \times B| = |A| \cdot |B|
+$$
+
+En este caso, cada elemento de $A$ puede emparejarse con todos los elementos de $B,$ lo que produce $|A| \cdot |B|$ pares ordenados.
+
+La cardinalidad de la unión de dos conjuntos $A$ y $B$ viene dada por:
+
+$$
+|A \cup B| = |A| + |B| - |A \cap B|
+$$
+
+La expresión anterior es el principio de inclusión-exclusión, que garantiza que los elementos comunes a ambos conjuntos se cuenten una sola vez. Cada elemento de $A \cup B$ aparece en la suma $|A| + |B|.$ Los elementos de $A \cap B$ se cuentan dos veces, por lo que se resta ese término para obtener el recuento correcto.
+
+El principio se extiende a tres conjuntos, como expresa la fórmula:
+
+$$
+|A \cup B \cup C| = |A| + |B| + |C| - |A \cap B| - |A \cap C| - |B \cap C| + |A \cap B \cap C|
+$$
+
+La estructura de la fórmula puede interpretarse del modo siguiente:
+
++ Los elementos que pertenecen a un solo conjunto se cuentan una única vez.
++ Los elementos compartidos por dos conjuntos se cuentan dos veces y se restan una vez, lo que da una contribución neta de $1.$
++ Los elementos que pertenecen a los tres conjuntos se suman tres veces, se restan tres veces y vuelven a sumarse una vez mediante la intersección triple, con lo que se obtiene de nuevo una contribución neta de uno.
+
+## Subconjuntos y conjuntos potencia
+
+Las nociones de subconjunto y conjunto potencia se introducen conjuntamente. Los subconjuntos son conjuntos cuyos elementos pertenecen todos a otro conjunto, mientras que los conjuntos potencia son conjuntos cuyos elementos son a su vez subconjuntos de un conjunto dado. Un conjunto $A$ es un subconjunto de $B$ si todo elemento de $A$ es también un elemento de $B$:
+
+$$
+A \subseteq B \iff \forall \ x, \ x \in A \rightarrow x \in B
+$$
+
+Dos conjuntos son iguales si y solo si cada uno está contenido en el otro, que es la forma habitual de demostrar la igualdad de conjuntos en matemáticas:
+
+$$
+A = B \iff A \subseteq B \text{ y } B \subseteq A
+$$
+
+Si $A \subseteq B$ y $A \neq B,$ entonces $A$ es un subconjunto propio de $B,$ denotado por $A \subsetneq B,$ y en este caso existe al menos un elemento de $B$ que no pertenece a $A.$ El conjunto vacío es un subconjunto de todo conjunto. La inclusión $\emptyset \subseteq A$ se cumple para cualquier conjunto $A,$ porque la implicación $x \in \emptyset \Rightarrow x \in A$ es verdadera por vacuidad.
+
+El conjunto potencia de un conjunto $A$ es el conjunto de todos los subconjuntos de $A,$ denotado por $\mathcal{P}(A).$ Incluye el conjunto vacío $\emptyset$ y el propio conjunto $A$. Si $A$ tiene $n$ elementos, entonces $\mathcal{P}(A)$ tiene $2^n$ elementos. Por ejemplo, si $A=\{a,b,c\},$ el conjunto potencia contiene $2^3=8$ elementos:
+
+$$
+\mathcal{P}(A) = \{\emptyset, \ \{a\}, \ \{b\}, \ \{c\}, \ \{a,b\}, \ \{a,c\}, \ \{b,c\}, \ \{a,b,c\}\}
+$$
+
+El exponente $2^n$ procede de una correspondencia con funciones. Todo subconjunto $E\subseteq A$ tiene una función característica $\chi_E\colon A\to\{0,1\}$ definida por:
+
+$$
+\chi_E(a)=
+\begin{cases}
+1 & \text{si } a\in E \\[6pt]
+0 & \text{si } a\notin E
+\end{cases}
+$$
+
+Recíprocamente, una función $\chi\colon A\to\{0,1\}$ determina el subconjunto $\{\ a\in A\mid \chi(a)=1\ \}.$ Estas dos construcciones son inversas entre sí. Cuando $A$ tiene $n$ elementos, el valor de $\chi$ admite dos posibilidades independientes en cada elemento de $A,$ por lo que existen $2^n$ funciones características y, por tanto, $2^n$ subconjuntos.
+
+
+## Familias indexadas de conjuntos
+
+Cuando se consideran varios conjuntos a la vez, asignarles un índice permite mantener compacta la notación. Una familia de conjuntos indexada por un conjunto $I$ asigna un conjunto $A_i$ a cada índice $i\in I$ y se escribe $(A_i)_{i\in I}.$ Formalmente, la familia es una función cuyo dominio es $I$ y cuyo valor en $i$ es $A_i.$ Los índices siguen siendo distintos aunque coincidan dos valores, de modo que $A_i=A_j$ no implica $i=j.$ El conjunto de índices puede ser finito, numerable o no numerable.
+
+La unión de la familia es el conjunto de los elementos que pertenecen al menos a uno de sus miembros, y la intersección es el conjunto de los elementos que pertenecen a todos ellos:
+
+$$
+\bigcup_{i\in I} A_i = \{\ x \mid x\in A_i \text{ para algún } i\in I \ \}
+$$
+
+$$
+\bigcap_{i\in I} A_i = \{\ x \mid x\in A_i \text{ para todo } i\in I \ \}
+$$
+
+Un elemento pertenece a la unión en cuanto lo contiene un miembro de la familia, y pertenece a la intersección solo cuando lo contienen todos los miembros.
+
+Una familia $(A_i)_{i\in I}$ es disjunta dos a dos cuando cualesquiera dos miembros con índices distintos no comparten ningún elemento:
+
+$$
+A_i \cap A_j = \emptyset \quad \forall \ i \neq j
+$$
+
+Para cada $n\in\mathbb{N}$, los conjuntos unitarios $\{n\}$ forman una familia disjunta dos a dos, y su unión es el conjunto $\mathbb{N}.$
+
+
+## Particiones
+
+Una partición de un conjunto $A$ es una familia de subconjuntos no vacíos $(A_i)_{i\in I}$ que son disjuntos dos a dos y cubren todo $A.$ Deben cumplirse las condiciones siguientes:
+
+$$
+\begin{align}
+&A_i \neq \emptyset \quad \forall \ i \in I \\[6pt]
+&A_i \cap A_j = \emptyset \quad \forall \ i \neq j \\[6pt]
+& \bigcup_{i \in I} A_i = A
+\end{align}
+$$
+
+Los subconjuntos $A_i$ se denominan bloques de la partición, y cada elemento de $A$ pertenece exactamente a uno de ellos. Un ejemplo sencillo es el conjunto de los [números enteros](../integers/) $\mathbb{Z},$ que puede dividirse en el conjunto de los enteros pares y el de los enteros impares, pues estos dos bloques son no vacíos, disjuntos y juntos cubren todo $\mathbb{Z}.$
+
+Las particiones están relacionadas con las relaciones de equivalencia. Dada una relación de equivalencia sobre $A$:
+
++ Las clases de equivalencia que induce forman una partición de $A.$
++ Toda partición de $A$ define una relación de equivalencia al declarar equivalentes dos elementos cuando pertenecen al mismo bloque.
+
+
+## Operaciones con conjuntos
+
+Las operaciones con conjuntos generan nuevos conjuntos combinando los elementos de conjuntos distintos. Las operaciones principales son la unión, la intersección, el complementario y la diferencia.
+
+La unión de $A$ y $B$ es el conjunto de todos los elementos que pertenecen al menos a uno de los dos conjuntos. Los elementos comunes a $A$ y $B$ se enumeran una sola vez, puesto que los conjuntos no admiten repeticiones.
+
+![IMG. 1](svg/sets-1.svg)
+
+$$
+A \cup B = \\{x \mid x \in A \text{ o } x \in B\\}
+$$
+- - -
+
+La intersección de $A$ y $B$ es el conjunto de los elementos que pertenecen a ambos conjuntos:
+
+![IMG. 2](svg/sets-2.svg)
+
+$$
+A \cap B = \\{x \mid x \in A \text{ y } x \in B\\}
+$$
+
+Si $A \cap B = \emptyset,$ los dos conjuntos son disjuntos y no comparten elementos.
+
+- - -
+
+El complementario de $A$ respecto de un conjunto universal $U$ es el conjunto de todos los elementos de $U$ que no pertenecen a $A.$ Se escribe:
+
+$$
+A^c = \\{x \in U \mid x \notin A\\}
+$$
+
+![IMG. 3](svg/sets-3.svg)
+
+Otra forma de representar el complementario de $A$ es $\overline{A}$ o $U \setminus A.$ Un mismo conjunto puede tener complementarios distintos al cambiar $U$, pues los elementos del complementario varían con el conjunto universal que se elija.
+
+- - -
+
+La diferencia de $A$ y $B,$ escrita $A \setminus B,$ es el conjunto de los elementos que pertenecen a $A$ pero no a $B$:
+
+![IMG. 4](svg/sets-4.svg)
+
+$$
+A \setminus B = \\{x \mid x \in A \text{ y } x \notin B\\}
+$$
+
+En general se cumple la relación $A \setminus B \neq B \setminus A$, ya que la diferencia de dos conjuntos no es una operación conmutativa. Para todo conjunto universal que contenga tanto $A$ como $B$ se cumple la identidad $A \setminus B = A \cap B^c$, que expresa la diferencia mediante el complementario.
+
+La diferencia simétrica de $A$ y $B,$ escrita $A \triangle B,$ es el conjunto de los elementos que pertenecen a uno de los dos conjuntos, pero no a ambos:
+
+![IMG. 5](svg/sets-5.svg)
+
+$$
+A \triangle B = (A \setminus B) \cup (B \setminus A)
+$$
+
+La expresión siguiente proporciona una representación equivalente:
+
+$$
+A \triangle B = (A \cup B) \setminus (A \cap B)
+$$
+
+La diferencia simétrica es conmutativa y asociativa, y satisface $A \triangle A = \emptyset$ y $A \triangle \emptyset = A.$ Junto con la intersección, dota de estructura de [anillo](../rings/) booleano a la colección de todos los subconjuntos de un conjunto dado.
+
+## Propiedades de las operaciones con conjuntos
+
+Las operaciones con conjuntos satisfacen una serie de identidades que constituyen la base del álgebra de Boole y se cumplen para cualesquiera conjuntos $A,$ $B,$ y $C$ contenidos en un conjunto universal $U.$ La unión y la intersección son operaciones conmutativas. El orden en que se combinan dos conjuntos no afecta al resultado.
+
+$$
+\begin{align}
+A \cup B &= B \cup A \\[6pt]
+A \cap B &= B \cap A
+\end{align}
+$$
+
+Ambas operaciones son también asociativas, lo que significa que, al combinar tres conjuntos, la agrupación de los operandos es irrelevante.
+
+$$
+\begin{align}
+(A \cup B) \cup C &= A \cup (B \cup C) \\[6pt]
+(A \cap B) \cap C &= A \cap (B \cap C)
+\end{align}
+$$
+
+La unión y la intersección son distributivas entre sí, de manera análoga a la propiedad distributiva de la aritmética.
+
+$$
+\begin{align}
+A \cap (B \cup C) &= (A \cap B) \cup (A \cap C) \\[6pt]
+A \cup (B \cap C) &= (A \cup B) \cap (A \cup C)
+\end{align}
+$$
+
+El conjunto vacío y el conjunto universal actúan como elementos neutros de la unión y la intersección, respectivamente. Al combinar cualquier conjunto con el elemento correspondiente se obtiene el conjunto original.
+
+$$
+\begin{align}
+A \cup \emptyset &= A \\[6pt]
+A \cap U &= A
+\end{align}
+$$
+
+El conjunto vacío es absorbente para la intersección y el conjunto universal lo es para la unión. Al combinar cualquier conjunto con estos elementos se obtiene el elemento absorbente en lugar del conjunto original:
+
+$$
+\begin{align}
+A \cap \emptyset &= \emptyset \\[6pt]
+A \cup U &= U
+\end{align}
+$$
+
+Cada elemento de $U$ pertenece a $A$ o a su complementario, pero nunca a ambos. Al aplicar dos veces seguidas la operación de complementación se recupera el conjunto original:
+
+$$
+\begin{align}
+A \cup A^c &= U \\[6pt]
+A \cap A^c &= \emptyset \\[6pt]
+(A^c)^c &= A
+\end{align}
+$$
+
+## Leyes de De Morgan
+
+Las leyes de De Morgan son identidades algebraicas que describen cómo se comportan la unión y la intersección bajo la operación de complementación. Estas identidades permiten reescribir expresiones de conjuntos en formas equivalentes y ayudan a simplificar las operaciones.
+
+$$
+\begin{align}
+(A \cup B)^c &= A^c \cap B^c \\[6pt]
+(A \cap B)^c &= A^c \cup B^c
+\end{align}
+$$
+
+La primera ley afirma que el complementario de una unión es igual a la intersección de los complementarios. Un elemento no pertenece a $A \cup B$ solo cuando no pertenece ni a $A$ ni a $B,$ lo que equivale a pertenecer tanto a $A^c$ como a $B^c.$
+
+![IMG. 6](svg/sets-6.svg)
+
+La segunda ley afirma que un elemento no pertenece a la intersección $A \cap B$ cuando falta en al menos uno de los dos conjuntos, por lo que pertenece a $A^c \cup B^c.$
+
+Estas leyes se extienden a una familia arbitraria de conjuntos $(A_i)_{i\in I},$ sin restricciones sobre el tamaño del conjunto de índices $I$:
+
+$$
+\begin{align}
+\left(\bigcup_{i \in I} A_i\right)^c &= \bigcap_{i \in I} A_i^c \\[6pt]
+\left(\bigcap_{i \in I} A_i\right)^c &= \bigcup_{i \in I} A_i^c
+\end{align}
+$$
+
+Existe una correspondencia entre la estructura algebraica de los conjuntos y la de las conectivas lógicas. Las leyes de De Morgan se traducen en las equivalencias siguientes para las conectivas $\land$ y $\lor$:
+
+$$
+\neg(P \lor Q) \equiv \neg P \land \neg Q
+$$
+
+$$
+\neg(P \land Q) \equiv \neg P \lor \neg Q
+$$
+
+La interpretación mediante tablas de verdad de estas equivalencias se desarrolla en [lógica proposicional](../propositional-logic/).
+
+## Ejemplo
+
+Sea $U = \\{1, 2, 3, 4, 5, 6, 7, 8, 9, 10\\}$ el conjunto universal, y definamos los dos subconjuntos siguientes:
+
+$$
+\begin{align}
+A &= \{1, 2, 3, 4, 6\} \\[6pt]
+B &= \{2, 4, 6, 8, 10\}
+\end{align}
+$$
+
+La unión y la intersección de los dos conjuntos se calculan directamente a partir de las definiciones:
+
+$$
+\begin{align}
+A \cup B &= \{1, 2, 3, 4, 6, 8, 10\} \\[6pt]
+A \cap B &= \{2, 4, 6\}
+\end{align}
+$$
+
+Los complementarios respecto de $U$ reúnen los elementos excluidos de cada conjunto:
+
+$$
+\begin{align}
+A^c &= \{5, 7, 8, 9, 10\} \\[6pt]
+B^c &= \{1, 3, 5, 7, 9\}
+\end{align}
+$$
+
+Comprobemos ahora la primera ley de De Morgan. El complementario de la unión es:
+
+$$
+(A \cup B)^c = U \setminus (A \cup B) = \\{5, 7, 9\\}
+$$
+
+La intersección de los complementarios da:
+
+$$
+\begin{align}
+A^c \cap B^c &= \{5, 7, 8, 9, 10\} \cap \{1, 3, 5, 7, 9\} \\[6pt]
+&= \{5, 7, 9\}
+\end{align}
+$$
+
+Los dos conjuntos coinciden, lo que confirma la primera ley de De Morgan. Comprobemos ahora el principio de inclusión-exclusión mediante cardinalidades:
+
+$$
+|A| = 5 \quad |B| = 5 \quad |A \cap B| = 3
+$$
+
+$$
+|A \cup B| = 5 + 5 - 3 = 7
+$$
+
+Un recuento directo de los elementos de $A \cup B = \\{1, 2, 3, 4, 6, 8, 10\\}$ confirma que $|A \cup B| = 7.$
+
+Calculamos la diferencia simétrica y comprobamos su relación con las demás operaciones:
+
+$$
+A \triangle B = (A \setminus B) \cup (B \setminus A)
+$$
+
+Las dos diferencias son $A \setminus B = \\{1, 3\\}$ y $B \setminus A = \\{8, 10\\},$ de donde se obtiene:
+
+$$
+A \triangle B = \\{1, 3, 8, 10\\}
+$$
+
+El mismo resultado se obtiene mediante la caracterización equivalente que utiliza la unión y la intersección:
+
+$$
+\begin{align}
+(A \cup B) \setminus (A \cap B) &= \{1, 2, 3, 4, 6, 8, 10\} \setminus \{2, 4, 6\} \\[6pt]
+&= \{1, 3, 8, 10\}
+\end{align}
+$$
+
+
+## Producto cartesiano
+
+Dados dos conjuntos $A$ y $B,$ el producto cartesiano $A \times B$ es el conjunto de todos los pares ordenados $(a, b)$ tales que $a$ pertenece a $A$ y $b$ pertenece a $B$:
+
+$$
+A \times B = \\{(a, b) \mid a \in A, \ b \in B\\}
+$$
+
+Un par ordenado es asimétrico: $(a, b)$ es distinto de $(b, a)$ si $a$ y $b$ no son iguales. Dos pares ordenados son iguales si y solo si sus componentes correspondientes son iguales, como expresa la condición siguiente:
+
+$$
+(a, b) = (a', b') \iff a = a' \text{ y } b = b'
+$$
+
+En general, $A \times B$ y $B \times A$ no son el mismo conjunto. Si $A$ contiene $m$ elementos y $B$ contiene $n$ elementos, entonces $A \times B$ contiene $mn$ elementos. Por ejemplo, $\mathbb{R} \times \mathbb{R},$ que es el conjunto de todos los pares de [números reales](../real-numbers/), es el plano cartesiano $\mathbb{R}^2.$
+
+Dados los conjuntos $A_1, A_2, \ldots, A_n,$ su producto cartesiano es el conjunto de todas las $n$-tuplas ordenadas:
+
+$$
+A_1 \times A_2 \times \cdots \times A_n = \\{(a_1, a_2, \ldots, a_n) \mid a_i \in A_i \text{ para todo } i = 1, \ldots, n\\}
+$$
+
+Una $n$-tupla $(a_1, \ldots, a_n)$ es una lista ordenada de $n$ elementos, y dos $n$-tuplas son iguales si y solo si todos sus componentes correspondientes son iguales. Si todos los conjuntos son idénticos, es decir, $A_i = A$ para todo $i,$ el producto es $A^n.$ El espacio $\mathbb{R}^n$ es el producto cartesiano de $n$ copias de $\mathbb{R}$, y sus elementos son $n$-tuplas de números reales.
+
+El producto cartesiano se extiende a una familia indexada $(A_i)_{i\in I}.$ Un elemento del producto indexado tiene un componente $a_i\in A_i$ por cada índice $i.$ El producto se define por:
+
+$$
+\prod_{i\in I}A_i=\{\ (a_i)_{i\in I}\mid a_i\in A_i \text{ para todo } i\in I \ \}
+$$
+
+De forma equivalente, un elemento de $\prod_{i\in I}A_i$ es una función $a\colon I\to\bigcup_{i\in I}A_i$ tal que $a(i)\in A_i$ para todo $i\in I.$ Cuando $I=\{1,\ldots,n\},$ esta definición proporciona el producto cartesiano finito anterior. Si uno de los factores es vacío, todo el producto es vacío porque ninguna familia puede elegir un elemento de ese factor.
+
+> Para una familia indexada arbitraria de conjuntos no vacíos, la afirmación de que el producto cartesiano no es vacío equivale al axioma de elección. Las familias finitas no necesitan este axioma.
+
+## Unión disjunta
+
+La unión ordinaria contiene una sola aparición de un elemento que pertenece tanto a $A$ como a $B.$ La unión disjunta contiene dos versiones etiquetadas de dicho elemento, una por cada conjunto de origen. Una construcción viene dada por:
+
+$$
+A\sqcup B=(\{0\}\times A)\cup(\{1\}\times B)
+$$
+
+Los conjuntos $\{0\}\times A$ y $\{1\}\times B$ son disjuntos porque sus pares ordenados tienen primeros componentes distintos. Las funciones $i_A\colon A\to A\sqcup B$ e $i_B\colon B\to A\sqcup B$ definidas por $i_A(a)=(0,a)$ e $i_B(b)=(1,b)$ son inyectivas. Sus imágenes son disjuntas y su unión es $A\sqcup B.$ Por tanto, cada elemento de la unión disjunta procede exactamente de uno de los dos conjuntos de origen.
+
+Si $A$ y $B$ son finitos, las dos copias etiquetadas tienen $|A|$ y $|B|$ elementos, respectivamente. El hecho de que sean disjuntas da la fórmula:
+
+$$
+|A\sqcup B|=|A|+|B|
+$$
+
+Cuando $A\cap B=\emptyset,$ eliminar las etiquetas define una biyección de $A\sqcup B$ en $A\cup B.$ Si $A\cap B\neq\emptyset,$ la misma regla no es inyectiva. Para un elemento $x\in A\cap B,$ los elementos distintos $(0,x)$ y $(1,x)$ de $A\sqcup B$ tendrían ambos como imagen $x.$
+
+## El par ordenado
+
+Hasta aquí se ha tratado el par ordenado $(a, b)$ como una noción intuitiva, a saber, un par de objetos cuyo primer componente es $a$ y cuyo segundo componente es $b.$ En términos formales, el par ordenado puede definirse en teoría de conjuntos como un conjunto que contiene dos elementos:
+
+$$
+(a, b) = \\{\\{a\\}, \ \\{a, b\\}\\}
+$$
+
+El término $\\{a\\}$ es el conjunto unitario, y $\\{a, b\\}$ es el par no ordenado. El elemento $a$ aparece en ambos, mientras que $b$ aparece solo en uno. Esta definición queda justificada por el resultado siguiente:
+
+$$
+(a, b) = (c, d) \implies a = c \text{ y } b = d
+$$
+
+Para comprobar esta propiedad, supongamos que $\\{\\{a\\}, \\{a, b\\}\\} = \\{\\{c\\}, \\{c, d\\}\\}.$ Hay dos casos, según se cumpla $a = b$ o $a \neq b.$
+
+En el primer caso, cuando $a = b,$ se tiene $\\{a, b\\} = \\{a\\},$ por lo que el miembro izquierdo se convierte en $\\{\\{a\\}\\},$ un conjunto unitario. Para que haya igualdad, el miembro derecho también debe ser un conjunto unitario, lo que exige que $\\{c\\} = \\{c, d\\}$ y, por tanto, que $c = d.$ El único elemento de cada miembro debe coincidir, de modo que $\\{a\\} = \\{c\\},$ y por consiguiente $a = c.$ Puesto que $b = a = c = d,$ se deduce que $a = c$ y $b = d.$
+
+Si $a \neq b,$ el miembro izquierdo contiene dos elementos distintos: $\\{a\\}$ y $\\{a, b\\}.$ El conjunto unitario $\\{a\\}$ debe corresponderse con $\\{c\\}$ o con $\\{c, d\\}$ en el miembro derecho. Si $\\{a\\} = \\{c, d\\},$ entonces $c = d = a,$ lo que haría que $\\{c\\} = \\{c, d\\},$ dando como resultado un conjunto unitario en el miembro derecho, en contradicción con la presencia de dos elementos distintos en el izquierdo. Por tanto, $\\{a\\} = \\{c\\},$ de modo que $a = c.$ Se sigue que $\\{a, b\\} = \\{c, d\\} = \\{a, d\\},$ y, dado que $a \neq b,$ necesariamente $b = d.$
+
+En ambos casos, $a = c$ y $b = d,$ como se quería demostrar. El recíproco es inmediato, pues si $a = c$ y $b = d$, los dos conjuntos son idénticos por sustitución.


### PR DESCRIPTION
## Purpose

Propose a repository structure for a community-maintained Spanish translation of Algebrica using the terminology and conventions customary in Spain (`es-ES`). The translated entries are placed in an `ESP` directory beside their English sources, following the existing language-directory pattern.

This pilot contains three representative entries:

- `Learning Mathematics` for prose-heavy content;
- `Sets` for equations, lists, internal links, and SVG references;
- `Propositional Logic` for formal notation and structured mathematical exposition.

The complete Spanish translation currently covers 291 published entries, but it is intentionally not included in this draft until the directory and metadata convention have been accepted.

## Translation approach

- Keep the English entries as the source of truth.
- Preserve Markdown structure, formulas, links, tables, diagrams, image references, tags, attribution, and licence.
- Keep generated PDFs and the separate book-building toolchain outside this repository.
- Use AI assistance transparently, followed by structural, mathematical, terminology, and residual-language validation.
- Check upstream changes weekly and submit translation updates explicitly; no automated translation or pull request creation.

## Validation

- Compared every pilot translation with its current English source.
- Confirmed matching mathematical structure, heading hierarchy, lists, links, images, and fenced content.
- Confirmed Spanish (`es-ES`) terminology and CC BY-NC 4.0 attribution.
- Confirmed that the contribution contains only Markdown files and no generated assets or build tooling.

This pull request is a draft so the proposed `ESP` layout can be reviewed before the remaining translations are submitted in manageable thematic batches.
